### PR TITLE
feat: Gomobile SDK implementation stubs

### DIFF
--- a/cmd/wallet-sdk-gomobile/README.md
+++ b/cmd/wallet-sdk-gomobile/README.md
@@ -2,6 +2,8 @@
 
 This package contains the `gomobile`-compatible version of the SDK.
 
-Currently, it only has a set of interface definitions, which are similar to the ones 
+Currently, it has
+* A set of interface definitions, which are similar to the ones 
 in [pkg/api.go](https://github.com/trustbloc/wallet-sdk/blob/main/pkg/api.go), but modified to
 be compatible with `gomobile`.
+* Stub methods for various SDK functionality.

--- a/cmd/wallet-sdk-gomobile/api/api.go
+++ b/cmd/wallet-sdk-gomobile/api/api.go
@@ -7,12 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 // Package api defines gomobile-compatible wallet-sdk interfaces.
 package api
 
+// KeyHandle represents a key with associated metadata.
 type KeyHandle struct {
 	Key     []byte `json:"key,omitempty"`
 	KeyType string `json:"keyType,omitempty"`
-	KeyID   string `json:"keyID,omitempty"`
+	KeyID   string `json:"keyID,omitempty"` //nolint: tagliatelle //false positive
 }
 
+// A KeyHandleWriter represents a type that is capable of performing certain operations related to writing key data.
 type KeyHandleWriter interface {
 	// Create a new key/keyset/key handle of type keyType
 	// Some key types may require additional attributes described in `opts`. // TODO: Format of opts to be determined.
@@ -25,7 +27,8 @@ type KeyHandleWriter interface {
 	Rotate(keyType, keyID string, opts string) (*KeyHandle, error)
 	// Import will import privKey into the KMS storage for the given keyType then returns the new key id and
 	// the newly persisted KeyHandle.
-	// privKey possible types are: *ecdsa.PrivateKey and ed25519.PrivateKey. // TODO: Determine how these restrictions work.
+	// privKey possible types are: *ecdsa.PrivateKey and ed25519.PrivateKey.
+	// TODO: Determine how these restrictions work.
 	// kt possible types are signing key types only (ECDSA keys or Ed25519)
 	// opts allows setting the keysetID of the imported key using WithKeyID() option. If the ID is already used,
 	// then an error is returned. // TODO: Format of opts to be determined.
@@ -33,34 +36,45 @@ type KeyHandleWriter interface {
 	// An error/exception will be returned/thrown if there is an import failure (key empty, invalid, doesn't match
 	// keyType, unsupported keyType or storing of key failed)
 	// TODO: Consider renaming this method to avoid keyword collision and automatic renaming to _import in Java
-	Import(privKey *KeyHandle, keyType, opts string) (*KeyHandle, error)
+	Import(privateKey *KeyHandle, keyType, opts string) (*KeyHandle, error)
 }
 
+// A KeyHandleReader represents a type that is capable of performing certain operations related to reading key data.
 type KeyHandleReader interface {
-	// GetKeyHandle key handle for the given keyID
-	// Returns the private key bytes
-	//  - error if failure
-	GetKeyHandle(keyID string) ([]byte, error)
+	// GetKeyHandle return the key handle for the given keyID
+	// Returns:
+	//  - The private key handle
+	//  - Error if failure
+	GetKeyHandle(keyID string) (*KeyHandle, error)
 	// Export will fetch a key referenced by id then gets its public key in raw bytes and returns it.
 	// The key must be an asymmetric key.
 	// Returns:
 	//  - A key handle, which contains both the key type and public key bytes
-	//  - error if it fails to export the public key bytes
+	//  - Error if it fails to export the public key bytes
 	Export(keyID string) (*KeyHandle, error)
 }
 
+// CreateDIDOpts represents the various options for the DIDCreator.Create method.
+type CreateDIDOpts struct {
+	// The type of DID to create (i.e. which DID method to use).
+	Method string
+}
+
+// DIDCreator defines the method required for a type to create DID documents.
 type DIDCreator interface {
 	// Create creates a new DID Document.
 	// It returns a DID Document Resolution.
-	Create(didDocument []byte) ([]byte, error)
+	Create(createDIDOpts CreateDIDOpts) ([]byte, error)
 }
 
+// DIDResolver defines the method required for a type to resolve DIDs.
 type DIDResolver interface {
 	// Resolve resolves a did.
 	// It returns a DID Document Resolution.
 	Resolve(did string) ([]byte, error)
 }
 
+// A CredentialReader is capable of reading VCs from some underlying storage mechanism.
 type CredentialReader interface {
 	// Get retrieves a VC.
 	Get(id string) ([]byte, error)
@@ -68,6 +82,7 @@ type CredentialReader interface {
 	GetAll() ([]byte, error)
 }
 
+// A CredentialWriter is capable of writing VCs to some underlying storage mechanism.
 type CredentialWriter interface {
 	// Remove removes a VC.
 	Remove(id string) error
@@ -75,6 +90,22 @@ type CredentialWriter interface {
 	Add(vc []byte) error
 }
 
+// Crypto defines useful Crypto operations.
+// TODO: Define more precisely the input and output formats.
+type Crypto interface {
+	// Sign will sign msg using a matching signature primitive in kh key handle of a private key
+	// returns:
+	// 		signature as []byte
+	//		error in case of errors
+	Sign(msg []byte, kh *KeyHandle) ([]byte, error)
+	// Verify will verify a signature for the given msg using a matching signature primitive in kh key handle of
+	// a public key
+	// returns:
+	// 		error in case of errors or nil if signature verification was successful
+	Verify(signature, msg []byte, kh *KeyHandle) error
+}
+
+// ActivityLog defines logging functionality.
 type ActivityLog interface {
 	// Log logs an activity.
 	Log(message string)

--- a/cmd/wallet-sdk-gomobile/credentialinquirer/credentialinquirer.go
+++ b/cmd/wallet-sdk-gomobile/credentialinquirer/credentialinquirer.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package credentialinquirer contains functionality for doing credential queries.
+package credentialinquirer
+
+import (
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/presentationexchange"
+)
+
+// Inquirer can perform credential queries.
+type Inquirer struct {
+	credentialReader     api.CredentialReader
+	presentationExchange presentationexchange.Exchange
+}
+
+// NewInquirer returns a new Inquirer.
+func NewInquirer(credentialReader api.CredentialReader, presentationExchange presentationexchange.Exchange) *Inquirer {
+	return &Inquirer{
+		credentialReader:     credentialReader,
+		presentationExchange: presentationExchange,
+	}
+}
+
+// Credentials represents the different ways that credentials can be passed in to the Query method.
+// At most one out of VCs and CredentialReader should be used for a given call to Query. If both are specified,
+// then VCs will take precedence. If neither are specified, then the CredentialReader from the constructor (NewInquirer)
+// will be used instead.
+type Credentials struct {
+	// VCs is a JSON array of Verifiable Credentials. If specified, this takes precedence over the CredentialReader
+	// used in the constructor (NewInquirer).
+	VCs []byte
+	// CredentialReader allows for access to a VC storage mechanism. If specified, this takes precedence over the
+	// CredentialReader used in the constructor (NewInquirer).
+	CredentialReader api.CredentialReader
+}
+
+// Query returns credentials that match the given query.
+// Query is the filter to be applied to the credentials (TODO: define format).
+// See the Credentials struct for more information on how to use it with this method.
+// Credentials are returned as a JSON array.
+func (*Inquirer) Query(query string, credentials *Credentials) ([]byte, error) {
+	return []byte("Example credentials"), nil
+}

--- a/cmd/wallet-sdk-gomobile/credentialschema/credentialschema.go
+++ b/cmd/wallet-sdk-gomobile/credentialschema/credentialschema.go
@@ -1,0 +1,56 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package credentialschema contains functionality for doing credential resolution with credential manifests.
+package credentialschema
+
+import "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+
+// Resolver can resolve credentials.
+type Resolver struct {
+	credentialReader api.CredentialReader
+}
+
+// NewResolver creates a new Resolver.
+// If a CredentialReader is specified here, then it will be used as the source for VCs in the Resolve method unless a
+// CredentialReader exists in the ResolveOpts.
+func NewResolver(credentialReader api.CredentialReader) *Resolver {
+	return &Resolver{credentialReader: credentialReader}
+}
+
+// Schema represents the schema options for the Resolve method.
+// Only one out of Schema and CredentialsSupported should be used for a given call to Resolve. If both are specified,
+// then Schema will take precedence.
+type Schema struct {
+	// CredentialManifest is the Credential Manifest to use for resolving descriptors.
+	CredentialManifest []byte
+	// CredentialsSupported is not yet defined (TODO: define).
+	CredentialsSupported []byte
+}
+
+// Credentials represents the different ways that credentials can be passed in to the Resolve method.
+// At most one out of VCs and CredentialReader should be used for a given call to Resolve. If both are specified,
+// then VCs will take precedence. If neither are specified, then the CredentialReader from the constructor (NewResolver)
+// will be used instead.
+// Optionally, CredentialID may be specified if only one VC out of VCs or the CredentialReader should be specified.
+type Credentials struct {
+	// VCs is a JSON array of Verifiable Credentials. If specified, this takes precedence over the CredentialReader
+	// used in the constructor (NewResolver).
+	VCs []byte
+	// CredentialReader allows for access to a VC storage mechanism. If specified, this takes precedence over the
+	// CredentialReader used in the constructor (NewResolver).
+	CredentialReader api.CredentialReader
+	// CredentialID specifies that only a single credential from VCs or the CredentialReader should be examined.
+	// If not specified, then all credentials from VCs or CredentialReader will be examined.
+	CredentialID string
+}
+
+// Resolve resolves the given credentials and returns resolved descriptors. See the Schema and Credentials structs
+// for more information.
+// Returns a JSON array of resolved descriptors.
+func (c *Resolver) Resolve(schema *Schema, credentials *Credentials) ([]byte, error) {
+	return []byte("Content"), nil
+}

--- a/cmd/wallet-sdk-gomobile/credentialsigner/credentialsigner.go
+++ b/cmd/wallet-sdk-gomobile/credentialsigner/credentialsigner.go
@@ -1,0 +1,55 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package credentialsigner contains functionality for doing credential signing operations.
+package credentialsigner
+
+import "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+
+// Signer is used to do credential signing operations.
+type Signer struct {
+	keyHandleReader  api.KeyHandleReader
+	didResolver      api.DIDResolver
+	credentialReader api.CredentialReader // Optional
+	crypto           api.Crypto
+}
+
+// NewSigner returns a new Signer instance.
+func NewSigner(keyHandleReader api.KeyHandleReader, didResolver api.DIDResolver, credentialReader api.CredentialReader,
+	crypto api.Crypto,
+) *Signer {
+	return &Signer{
+		keyHandleReader:  keyHandleReader,
+		didResolver:      didResolver,
+		credentialReader: credentialReader,
+		crypto:           crypto,
+	}
+}
+
+// Issue issues a credential.
+// credential must be a valid marshalled VC in JSON form.
+// TODO: Format of proofOpts to be determined.
+// Returns a credential.
+func (s *Signer) Issue(credential []byte, id, proofOpts string) ([]byte, error) {
+	return []byte("Sample data"), nil
+}
+
+// Derive does something (TODO: Implement).
+// credential must be a valid marshalled VC in JSON form.
+// Returns a credential.
+func (s *Signer) Derive(credential []byte, id string, jsonFrame []byte, nonce string) ([]byte, error) {
+	return []byte("Sample credential"), nil
+}
+
+// Prove does something (TODO: Implement).
+// credentials must be valid marshalled VCs in a JSON array.
+// ids must be a JSON array.
+// presentation must be a valid marshalled presentation in JSON form.
+// TODO: Format of proofOpts to be determined.
+// Returns a presentation.
+func (s *Signer) Prove(credentials, ids, presentation []byte, proofOpts string) ([]byte, error) {
+	return []byte("Sample presentation"), nil
+}

--- a/cmd/wallet-sdk-gomobile/credentialverifier/credentialverifier.go
+++ b/cmd/wallet-sdk-gomobile/credentialverifier/credentialverifier.go
@@ -1,0 +1,48 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package credentialverifier contains functionality for doing credential verification.
+package credentialverifier
+
+import "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+
+// Verifier is used to verify credentials.
+type Verifier struct {
+	keyHandleReader  api.KeyHandleReader
+	didResolver      api.DIDResolver
+	credentialReader api.CredentialReader
+	crypto           api.Crypto
+}
+
+// NewVerifier returns a new Verifier.
+func NewVerifier(keyHandleReader api.KeyHandleReader, didResolver api.DIDResolver,
+	credentialReader api.CredentialReader, crypto api.Crypto,
+) *Verifier {
+	return &Verifier{
+		keyHandleReader:  keyHandleReader,
+		didResolver:      didResolver,
+		credentialReader: credentialReader,
+		crypto:           crypto,
+	}
+}
+
+// VerifyOpts represents the various options for the Verify method.
+// Only of these three should be used for a given call to Verify. If multiple options are used, then one of them will
+// take precedence over the other per the following order: CredentialID, RawCredential, RawPresentation.
+type VerifyOpts struct {
+	// CredentialID is the ID of the credential to be verified.
+	// A credential with the given ID must be found in this Verifier's credentialReader.
+	CredentialID string
+	// RawCredential is the raw credential to be verified.
+	RawCredential []byte
+	// RawPresentation is the raw presentation to be verified.
+	RawPresentation []byte
+}
+
+// Verify verifies the given credential or presentation. See the VerifyOpts struct for more information.
+func (*Verifier) Verify(verifyOpts VerifyOpts) error {
+	return nil
+}

--- a/cmd/wallet-sdk-gomobile/go.mod
+++ b/cmd/wallet-sdk-gomobile/go.mod
@@ -1,8 +1,19 @@
+// Copyright SecureKey Technologies Inc. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 module github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile
 
 go 1.19
 
 require (
+	github.com/google/uuid v1.3.0
+	github.com/tidwall/gjson v1.14.3
+)
+
+require (
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/mobile v0.0.0-20221012134814-c746ac228303 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde // indirect

--- a/cmd/wallet-sdk-gomobile/go.sum
+++ b/cmd/wallet-sdk-gomobile/go.sum
@@ -1,4 +1,12 @@
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
+github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/cmd/wallet-sdk-gomobile/kms/kms.go
+++ b/cmd/wallet-sdk-gomobile/kms/kms.go
@@ -1,0 +1,79 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package kms contains a KMS implementation.
+package kms
+
+import "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+
+// A KeyManager manages key creation, storage, retrieval, and other related functionality.
+type KeyManager struct{}
+
+// NewKeyManager returns a new KeyManager instance.
+func NewKeyManager() *KeyManager {
+	return &KeyManager{}
+}
+
+// Create a new key/keyset/key handle of type keyType
+// Some key types may require additional attributes described in `opts`. // TODO: Format of opts to be determined.
+// Returns a key handle, which contains both the key ID and actual private key bytes.
+func (k *KeyManager) Create(keyType, opts string) (*api.KeyHandle, error) {
+	return &api.KeyHandle{
+		Key:     []byte("Key Bytes"),
+		KeyType: keyType,
+		KeyID:   "SomeKeyID",
+	}, nil
+}
+
+// Rotate a key referenced by keyID and return a new handle of a keyset including old key and
+// new key of type keyType. It also returns the updated keyID as the first return value
+// Some key types may require additional attributes described in `opts` // TODO: Format of opts to be determined.
+// Returns: a key handle, which contains both the new key ID and actual private key bytes.
+func (k *KeyManager) Rotate(keyType, keyID, opts string) (*api.KeyHandle, error) {
+	return &api.KeyHandle{
+		Key:     []byte("Key Bytes"),
+		KeyType: keyType,
+		KeyID:   keyID,
+	}, nil
+}
+
+// Import will import privKey into the KMS storage for the given keyType then returns the new key id and
+// the newly persisted KeyHandle.
+// privKey possible types are: *ecdsa.PrivateKey and ed25519.PrivateKey. // TODO: Determine how these restrictions work.
+// kt possible types are signing key types only (ECDSA keys or Ed25519)
+// opts allows setting the keysetID of the imported key using WithKeyID() option. If the ID is already used,
+// then an error is returned. // TODO: Format of opts to be determined.
+// Returns: a key handle, which contains both the new key ID and actual private key bytes.
+// An error/exception will be returned/thrown if there is an import failure (key empty, invalid, doesn't match
+// keyType, unsupported keyType or storing of key failed)
+// TODO: Consider renaming this method to avoid keyword collision and automatic renaming to _import in Java.
+func (k *KeyManager) Import(privateKey *api.KeyHandle, keyType, opts string) (*api.KeyHandle, error) {
+	return privateKey, nil
+}
+
+// GetKeyHandle return the key handle for the given keyID
+// Returns the private key handle
+//   - Error if failure.
+func (k *KeyManager) GetKeyHandle(keyID string) (*api.KeyHandle, error) {
+	return &api.KeyHandle{
+		Key:     []byte("Key Bytes"),
+		KeyType: "SomeKeyType",
+		KeyID:   keyID,
+	}, nil
+}
+
+// Export will fetch a key referenced by id then gets its public key in raw bytes and returns it.
+// The key must be an asymmetric key.
+// Returns:
+//   - A key handle, which contains both the key type and public key bytes.
+//   - Error if it fails to export the public key bytes.
+func (k *KeyManager) Export(keyID string) (*api.KeyHandle, error) {
+	return &api.KeyHandle{
+		Key:     []byte("SomeKey"),
+		KeyType: "SomeKeyType",
+		KeyID:   keyID,
+	}, nil
+}

--- a/cmd/wallet-sdk-gomobile/linkeddomains/linkeddomains.go
+++ b/cmd/wallet-sdk-gomobile/linkeddomains/linkeddomains.go
@@ -1,0 +1,16 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package linkeddomains contains functionality for dealing with linked domains.
+package linkeddomains
+
+// LD represents a type that can help with linked domains. TODO: Implement.
+type LD struct{}
+
+// NewLD returns a new LD instance. TODO: Implement.
+func NewLD() *LD {
+	return &LD{}
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/openid4ci.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/openid4ci.go
@@ -1,0 +1,42 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package openid4ci contains functionality for doing OpenID4CI operations.
+package openid4ci
+
+import "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+
+// Instance helps with OpenID4CI operations.
+type Instance struct {
+	initiateIssuanceRequest []byte
+	format                  string
+	clientCredentialReader  api.CredentialReader
+	keyHandleReader         api.KeyHandleReader
+	didResolver             api.DIDResolver
+}
+
+// NewInstance returns a new OpenID4CI Instance.
+func NewInstance(initiateIssuanceRequest []byte, format string, clientCredentialReader api.CredentialReader,
+	keyHandleReader api.KeyHandleReader, didResolver api.DIDResolver,
+) *Instance {
+	return &Instance{
+		initiateIssuanceRequest: initiateIssuanceRequest,
+		format:                  format,
+		clientCredentialReader:  clientCredentialReader,
+		keyHandleReader:         keyHandleReader,
+		didResolver:             didResolver,
+	}
+}
+
+// Authorize does something (TODO: Implement).
+func (o *Instance) Authorize(preAuthorizedCode, authorizationRedirectEndpoint string) error {
+	return nil
+}
+
+// RequestCredential does something (TODO: Implement).
+func (o *Instance) RequestCredential(authCode, kid string) ([]byte, error) {
+	return []byte("Credential"), nil
+}

--- a/cmd/wallet-sdk-gomobile/openid4vp/openid4vp.go
+++ b/cmd/wallet-sdk-gomobile/openid4vp/openid4vp.go
@@ -1,0 +1,43 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package openid4vp contains functionality for doing OpenID4VP operations.
+package openid4vp
+
+import (
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/linkeddomains"
+)
+
+// Instance is used to help with OpenID4VP operations (TODO: Implement).
+type Instance struct {
+	authorizationRequest []byte
+	keyHandleReader      api.KeyHandleReader
+	didResolver          api.DIDResolver
+	linkedDomains        linkeddomains.LD
+}
+
+// NewInstance returns a new OpenID4VP Instance.
+func NewInstance(authorizationRequest []byte, keyHandleReader api.KeyHandleReader,
+	didResolver api.DIDResolver, linkedDomains linkeddomains.LD,
+) (*Instance, error) {
+	return &Instance{
+		authorizationRequest: authorizationRequest,
+		keyHandleReader:      keyHandleReader,
+		didResolver:          didResolver,
+		linkedDomains:        linkedDomains,
+	}, nil
+}
+
+// GetQuery does something (TODO: Implement).
+func (o *Instance) GetQuery() ([]byte, error) {
+	return []byte("Example"), nil
+}
+
+// PresentCredential does something (TODO: Implement).
+func (o *Instance) PresentCredential(presentation []byte, kid string) error {
+	return nil
+}

--- a/cmd/wallet-sdk-gomobile/presentationexchange/presentationexchange.go
+++ b/cmd/wallet-sdk-gomobile/presentationexchange/presentationexchange.go
@@ -1,0 +1,21 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package presentationexchange defines functionality for doing presentation exchange operations.
+package presentationexchange
+
+// An Exchange is used to perform matching operations.
+type Exchange struct{}
+
+// NewExchange returns a new Exchange object.
+func NewExchange() *Exchange {
+	return &Exchange{}
+}
+
+// Match does something (TODO: Implement).
+func (p *Exchange) Match(presentationDefinition, vp []byte, matchOptions string) ([]byte, error) {
+	return []byte("Example data"), nil
+}

--- a/cmd/wallet-sdk-gomobile/storage/storage.go
+++ b/cmd/wallet-sdk-gomobile/storage/storage.go
@@ -1,0 +1,70 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package storage contains a storage implementation.
+package storage
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/tidwall/gjson"
+)
+
+// A Provider allows for credential storage and retrieval.
+type Provider struct {
+	credentialStore map[string][]byte
+}
+
+// NewProvider returns a new Provider.
+func NewProvider() *Provider {
+	return &Provider{credentialStore: map[string][]byte{}}
+}
+
+// Get returns a credential with the given id. An error is returned if no credential exists with the given id.
+func (p *Provider) Get(id string) ([]byte, error) {
+	credential, exists := p.credentialStore[id]
+	if !exists {
+		return nil, fmt.Errorf("no credential with an id of %s was found", id)
+	}
+
+	return credential, nil
+}
+
+// GetAll returns all stored credentials.
+func (p *Provider) GetAll() ([]byte, error) {
+	credentials := make([][]byte, len(p.credentialStore))
+
+	var counter int
+
+	for _, credential := range p.credentialStore {
+		credentials[counter] = credential
+		counter++
+	}
+
+	credentialsAsJSONArray, err := json.Marshal(credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	return credentialsAsJSONArray, nil
+}
+
+// Remove removes the credential with the matching id, if it exists.
+func (p *Provider) Remove(id string) error {
+	delete(p.credentialStore, id)
+
+	return nil
+}
+
+// Add stores the given credential.
+func (p *Provider) Add(vc []byte) error {
+	vcID := gjson.GetBytes(vc, "id")
+
+	p.credentialStore[vcID.String()] = vc
+
+	return nil
+}

--- a/cmd/wallet-sdk-gomobile/vdr/vdr.go
+++ b/cmd/wallet-sdk-gomobile/vdr/vdr.go
@@ -1,0 +1,21 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package vdr contains functionality for doing VDR operations.
+package vdr
+
+// VerifiableDataRegistry performs VDR operations.
+type VerifiableDataRegistry struct{}
+
+// Create does something // TODO: Complete this.
+func (v *VerifiableDataRegistry) Create(didDocument []byte) ([]byte, error) {
+	return didDocument, nil
+}
+
+// Resolve does something // TODO: Complete this.
+func (v *VerifiableDataRegistry) Resolve(did string) ([]byte, error) {
+	return []byte("DID document"), nil
+}

--- a/cmd/wallet-sdk-gomobile/wallethandle/wallethandle.go
+++ b/cmd/wallet-sdk-gomobile/wallethandle/wallethandle.go
@@ -1,0 +1,39 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package wallethandle contains functionality for doing wallet import and export operations.
+package wallethandle
+
+import "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+
+// A Handle exposes wallet import and export functionality.
+type Handle struct {
+	credentialReader api.CredentialReader
+	credentialWriter api.CredentialWriter
+	crypto           api.Crypto
+}
+
+// NewHandle returns a new Handle instance.
+func NewHandle(credentialReader api.CredentialReader, credentialWriter api.CredentialWriter,
+	crypto api.Crypto,
+) *Handle {
+	return &Handle{
+		credentialReader: credentialReader,
+		credentialWriter: credentialWriter,
+		crypto:           crypto,
+	}
+}
+
+// Import imports the given credentials into the wallet.
+// The credentials are expected to be a JSON array.
+func (w *Handle) Import(credentials []byte) error {
+	return nil
+}
+
+// Export returns all credentials stored in this wallet.
+func (w *Handle) Export() ([]byte, error) {
+	return []byte("Sample data"), nil
+}

--- a/pkg/api.go
+++ b/pkg/api.go
@@ -4,6 +4,7 @@ Copyright SecureKey Technologies Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+// Package pkg defines wallet-sdk APIs.
 package pkg
 
 import (
@@ -29,9 +30,9 @@ type KeyHandleWriter interface {
 	//  - handle instance (to private key)
 	//  - error if failure
 	Rotate(kt kms.KeyType, keyID string, opts ...kms.KeyOpts) (string, interface{}, error)
-	// Import will import privKey into the KMS storage for the given keyType then returns the new key id and
+	// Import will import privateKey into the KMS storage for the given keyType then returns the new key id and
 	// the newly persisted Handle.
-	// 'privKey' possible types are: *ecdsa.PrivateKey and ed25519.PrivateKey
+	// 'privateKey' possible types are: *ecdsa.PrivateKey and ed25519.PrivateKey
 	// 'kt' possible types are signing key types only (ECDSA keys or Ed25519)
 	// 'opts' allows setting the keysetID of the imported key using WithKeyID() option. If the ID is already used,
 	// then an error is returned.
@@ -39,7 +40,7 @@ type KeyHandleWriter interface {
 	//  - keyID of the handle
 	//  - handle instance (to private key)
 	//  - error if import failure (key empty, invalid, doesn't match keyType, unsupported keyType or storing key failed)
-	Import(privKey interface{}, kt kms.KeyType, opts ...kms.PrivateKeyOpts) (string, interface{}, error)
+	Import(privateKey interface{}, kt kms.KeyType, opts ...kms.PrivateKeyOpts) (string, interface{}, error)
 }
 
 // KeyHandleReader defines key handler reader APIs.
@@ -83,6 +84,20 @@ type CredentialWriter interface {
 	Remove(id string) error
 	// Add adds a VC.
 	Add(vc *verifiable.Credential) error
+}
+
+// Crypto defines various crypto operations that may be used with wallet-sdk APIs.
+type Crypto interface {
+	// Sign will sign msg using a matching signature primitive in kh key handle of a private key
+	// returns:
+	// 		signature in []byte
+	//		error in case of errors
+	Sign(msg []byte, kh interface{}) ([]byte, error)
+	// Verify will verify a signature for the given msg using a matching signature primitive in kh key handle of
+	// a public key
+	// returns:
+	// 		error in case of errors or nil if signature verification was successful
+	Verify(signature, msg []byte, kh interface{}) error
 }
 
 // ActivityLog defines activity log related APIs.

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -1,8 +1,0 @@
-/*
-Copyright SecureKey Technologies Inc. All Rights Reserved.
-
-SPDX-License-Identifier: Apache-2.0
-*/
-
-// Package pkg defines wallet-sdk APIs.
-package pkg

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -16,4 +16,7 @@ if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0
 fi
 
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+echo "Linting top-level module..."
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/ ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m
+echo "Linting wallet-sdk-gomobile..."
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace/cmd/wallet-sdk-gomobile ${GOLANGCI_LINT_IMAGE} golangci-lint run --timeout 5m


### PR DESCRIPTION
Added stubs for various SDK functionality. This is intended as a simple starting point to allow for testing of the gomobile bindings. Real functionality still needs to be added, and the method signatures and comments/documentation still need to be worked on. Many of them are just placeholders.

Some other notes:
* Added a Crypto interface.
* For the storage implementation stubs, I added very basic storage functionality that we can try using while testing out the gomobile bindings.
* Updated linter script to lint the wallet-sdk-gomobile folder.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>