### PR TITLE
ci: upload artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPATH: /home/runner/work/wallet-sdk/go
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: android-binding
+          path: ./cmd/wallet-sdk-gomobile/bindings/android
 
   GenerateiOSBinding:
     runs-on: macos-latest
@@ -106,3 +111,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPATH: /Users/runner/work/wallet-sdk/go
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ios-binding
+          path: ./cmd/wallet-sdk-gomobile/bindings/ios


### PR DESCRIPTION
Once Bindings are created, the CI will upload Android/iOS bindings to Github artifacts.

Signed-off-by: Rolson Quadras <rolson.quadras@avast.com>