### PR TITLE
docs: Update DID creator method docs, update imports in test file

### DIFF
--- a/cmd/wallet-sdk-gomobile/didcreator/didcreator.go
+++ b/cmd/wallet-sdk-gomobile/didcreator/didcreator.go
@@ -66,7 +66,7 @@ func NewCreatorWithKeyReader(keyReader api.KeyReader) (*Creator, error) {
 //
 //	If the Creator was created using the NewCreatorWithKeyWriter function, then both of those options are ignored.
 //	An ED25519 key will be generated and saved automatically, and the verification type will automatically be set to
-//	Ed25519VerificationKey2018.
+//	Ed25519VerificationKey2018. TODO (#51): Support more key types. ED25519 is the chosen default for now.
 //	If the Creator was created using the NewCreatorWithKeyReader function, then you must specify the KeyID and also
 //	the VerificationType in the createDIDOpts object to use for the creation of the DID document.
 func (d *Creator) Create(method string, createDIDOpts *api.CreateDIDOpts) ([]byte, error) {

--- a/pkg/did/creator/creator.go
+++ b/pkg/did/creator/creator.go
@@ -64,8 +64,8 @@ func NewCreatorWithKeyReader(keyReader api.KeyReader) (*Creator, error) {
 // VerificationType.
 //
 //	If the Creator was created using the NewCreatorWithKeyWriter function, then both of those options are ignored.
-//	An ED25519 key will be generated and saved automatically, and the verification type will automatically be set to
-//	Ed25519VerificationKey2018.
+//	ED25519 key will be generated and saved automatically, and the verification type will automatically be set to
+//	Ed25519VerificationKey2018. TODO (#51): Support more key types. ED25519 is the chosen default for now.
 //	If the Creator was created using the NewCreatorWithKeyReader function, then you must specify the KeyID and also
 //	the VerificationType in the createDIDOpts object to use for the creation of the DID document.
 func (d *Creator) Create(method string, createDIDOpts *api.CreateDIDOpts) (*did.DocResolution, error) {

--- a/pkg/did/creator/creator_test.go
+++ b/pkg/did/creator/creator_test.go
@@ -11,12 +11,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/trustbloc/wallet-sdk/pkg/localkms"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/wallet-sdk/pkg/api"
 	"github.com/trustbloc/wallet-sdk/pkg/did/creator"
+	"github.com/trustbloc/wallet-sdk/pkg/localkms"
 )
 
 type mockKeyHandleReader struct {


### PR DESCRIPTION
* Added a TODO in the DID creator Create method docs.
* Updated import statement grouping in creator_test.go file for consistency with the format required by the linter for non-test files.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>