### PR TITLE
feat: Resolve function for OpenID4CI display data

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,6 +90,7 @@ linters:
     - exhaustruct # Results in unneeded struct member declarations
     - ireturn # Required by aries-framework-go, a library we use
     - tagliatelle # JSON tags using camel-case required by the specs we implement
+    - varnamelen # This linter prevents us from using "i" as an index variable or "vc" for a variable name for a Verifiable Credential, both of which are very common in our code
 
 issues:
   exclude-use-default: false

--- a/cmd/wallet-sdk-gomobile/credentialschema/credentialschema_test.go
+++ b/cmd/wallet-sdk-gomobile/credentialschema/credentialschema_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialschema_test
+
+import (
+	_ "embed"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/memstorage"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/credentialschema"
+)
+
+var (
+	//go:embed testdata/issuer_metadata.json
+	sampleIssuerMetadata []byte
+
+	//go:embed testdata/credential_university_degree.jsonld
+	credentialUniversityDegree string
+)
+
+type mockIssuerServerHandler struct{}
+
+func (m *mockIssuerServerHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
+	_, err := writer.Write(sampleIssuerMetadata)
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Run("Directly passing in VC", func(t *testing.T) {
+			vcs := fmt.Sprintf("[%s]", credentialUniversityDegree)
+
+			credentials := credentialschema.Credentials{
+				VCs: &api.JSONArray{Data: []byte(vcs)},
+			}
+
+			issuerMetadata := credentialschema.IssuerMetadata{
+				Metadata: &api.JSONObject{Data: sampleIssuerMetadata},
+			}
+
+			resolvedDisplayData, err := credentialschema.Resolve(&credentials, &issuerMetadata, "en-US")
+			require.NoError(t, err)
+			require.NotEmpty(t, resolvedDisplayData)
+		})
+		t.Run("With credential reader", func(t *testing.T) {
+			memProvider := memstorage.NewProvider()
+
+			vc := &api.JSONObject{Data: []byte(credentialUniversityDegree)}
+
+			err := memProvider.Add(vc)
+			require.NoError(t, err)
+
+			credentials := credentialschema.Credentials{
+				Reader: memProvider,
+				IDs:    &api.JSONArray{Data: []byte(`["http://example.edu/credentials/1872"]`)},
+			}
+
+			issuerMetadata := credentialschema.IssuerMetadata{
+				Metadata: &api.JSONObject{Data: sampleIssuerMetadata},
+			}
+
+			resolvedDisplayData, err := credentialschema.Resolve(&credentials, &issuerMetadata, "en-US")
+			require.NoError(t, err)
+			require.NotEmpty(t, resolvedDisplayData)
+		})
+		t.Run("Using issuer URI", func(t *testing.T) {
+			issuerServerHandler := &mockIssuerServerHandler{}
+			server := httptest.NewServer(issuerServerHandler)
+
+			defer server.Close()
+
+			vcs := fmt.Sprintf("[%s]", credentialUniversityDegree)
+
+			credentials := credentialschema.Credentials{
+				VCs: &api.JSONArray{Data: []byte(vcs)},
+			}
+
+			issuerMetadata := credentialschema.IssuerMetadata{
+				IssuerURI: server.URL,
+			}
+
+			resolvedDisplayData, err := credentialschema.Resolve(&credentials, &issuerMetadata, "en-US")
+			require.NoError(t, err)
+			require.NotEmpty(t, resolvedDisplayData)
+		})
+	})
+	t.Run("No credentials specified", func(t *testing.T) {
+		t.Run("Error from wallet-sdk-gomobile layer", func(t *testing.T) {
+			resolvedDisplayData, err := credentialschema.Resolve(nil, nil, "")
+			require.EqualError(t, err, "no credentials specified")
+			require.Nil(t, resolvedDisplayData)
+		})
+		t.Run("Error from Go SDK layer", func(t *testing.T) {
+			resolvedDisplayData, err := credentialschema.Resolve(&credentialschema.Credentials{},
+				&credentialschema.IssuerMetadata{}, "")
+			require.EqualError(t, err, "no credentials specified")
+			require.Nil(t, resolvedDisplayData)
+		})
+	})
+	t.Run("No issuer metadata source specified", func(t *testing.T) {
+		resolvedDisplayData, err := credentialschema.Resolve(&credentialschema.Credentials{}, nil, "")
+		require.EqualError(t, err, "no issuer metadata source specified")
+		require.Nil(t, resolvedDisplayData)
+	})
+	t.Run("VCs are not provided as a JSON array", func(t *testing.T) {
+		resolvedDisplayData, err := credentialschema.Resolve(&credentialschema.Credentials{
+			VCs: &api.JSONArray{Data: []byte("NotAJSONArray")},
+		}, &credentialschema.IssuerMetadata{}, "")
+		require.EqualError(t, err, "failed to unmarshal VCs into an array: invalid character 'N' "+
+			"looking for beginning of value")
+		require.Nil(t, resolvedDisplayData)
+	})
+	t.Run("Failed to parse VC", func(t *testing.T) {
+		resolvedDisplayData, err := credentialschema.Resolve(&credentialschema.Credentials{
+			VCs: &api.JSONArray{Data: []byte(`[{}]`)},
+		}, &credentialschema.IssuerMetadata{}, "")
+		require.EqualError(t, err, "failed to parse credential: build new credential: "+
+			"fill credential types from raw: credential type of unknown structure")
+		require.Nil(t, resolvedDisplayData)
+	})
+	t.Run("Credential IDs are nil", func(t *testing.T) {
+		memProvider := memstorage.NewProvider()
+
+		vc := &api.JSONObject{Data: []byte(credentialUniversityDegree)}
+
+		err := memProvider.Add(vc)
+		require.NoError(t, err)
+
+		credentials := credentialschema.Credentials{
+			Reader: memProvider,
+			IDs:    &api.JSONArray{},
+		}
+
+		issuerMetadata := credentialschema.IssuerMetadata{
+			Metadata: &api.JSONObject{Data: sampleIssuerMetadata},
+		}
+
+		resolvedDisplayData, err := credentialschema.Resolve(&credentials, &issuerMetadata, "en-US")
+		require.EqualError(t, err, "failed to unmarshal credential IDs into a []string: "+
+			"unexpected end of JSON input")
+		require.Nil(t, resolvedDisplayData)
+	})
+}

--- a/cmd/wallet-sdk-gomobile/credentialschema/opts.go
+++ b/cmd/wallet-sdk-gomobile/credentialschema/opts.go
@@ -1,0 +1,167 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialschema
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/piprate/json-gold/ld"
+
+	"github.com/trustbloc/wallet-sdk/cmd/utilities/gomobilewrappers"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+	goapicredentialschema "github.com/trustbloc/wallet-sdk/pkg/credentialschema"
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+// We don't check here to see if multiple conflicting options are used - that's left up to the
+// goapicredentialschema.Resolve method that get called after this function returns.
+func prepareOpts(credentials *Credentials, issuerMetadata *IssuerMetadata,
+	preferredLocale string,
+) ([]goapicredentialschema.ResolveOpt, error) {
+	if credentials == nil {
+		return nil, errors.New("no credentials specified")
+	}
+
+	if issuerMetadata == nil {
+		return nil, errors.New("no issuer metadata source specified")
+	}
+
+	var opts []goapicredentialschema.ResolveOpt
+
+	credentialOpts, err := prepareCredentialsOpts(credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, credentialOpts...)
+
+	issuerMetadataOpts, err := prepareIssuerMetadataOpts(issuerMetadata, preferredLocale)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, issuerMetadataOpts...)
+
+	return opts, nil
+}
+
+func prepareCredentialsOpts(credentials *Credentials) ([]goapicredentialschema.ResolveOpt, error) {
+	var opts []goapicredentialschema.ResolveOpt
+
+	if credentials.VCs != nil && credentials.VCs.Data != nil {
+		opt, err := generateWithCredentialsOpt(credentials.VCs)
+		if err != nil {
+			return nil, err
+		}
+
+		opts = append(opts, opt)
+	}
+
+	if credentials.Reader != nil {
+		opt, err := generateWithCredentialReaderOpt(credentials)
+		if err != nil {
+			return nil, err
+		}
+
+		opts = append(opts, opt)
+	}
+
+	return opts, nil
+}
+
+func generateWithCredentialsOpt(vcs *api.JSONArray) (goapicredentialschema.ResolveOpt, error) {
+	var vcsRaw []interface{}
+
+	err := json.Unmarshal(vcs.Data, &vcsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal VCs into an array: %w", err)
+	}
+
+	var credentials []*verifiable.Credential
+
+	for _, vcRaw := range vcsRaw {
+		vcBytes, err := json.Marshal(vcRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		credential, err := verifiable.ParseCredential(vcBytes,
+			verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+			verifiable.WithDisabledProofCheck())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse credential: %w", err)
+		}
+
+		credentials = append(credentials, credential)
+	}
+
+	return goapicredentialschema.WithCredentials(credentials), nil
+}
+
+func generateWithCredentialReaderOpt(credentials *Credentials) (goapicredentialschema.ResolveOpt, error) {
+	var ids []string
+
+	if credentials.IDs != nil {
+		err := json.Unmarshal(credentials.IDs.Data, &ids)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal credential IDs into a []string: %w", err)
+		}
+	}
+
+	opt := goapicredentialschema.WithCredentialReader(&gomobilewrappers.CredentialReaderWrapper{
+		CredentialReader: credentials.Reader,
+		DocumentLoader:   ld.NewDefaultDocumentLoader(http.DefaultClient),
+	}, ids)
+
+	return opt, nil
+}
+
+func prepareIssuerMetadataOpts(issuerMetadata *IssuerMetadata,
+	preferredLocale string,
+) ([]goapicredentialschema.ResolveOpt, error) {
+	var opts []goapicredentialschema.ResolveOpt
+
+	if issuerMetadata.IssuerURI != "" {
+		opt := goapicredentialschema.WithIssuerURI(issuerMetadata.IssuerURI)
+
+		opts = append(opts, opt)
+	}
+
+	if issuerMetadata.Metadata != nil && issuerMetadata.Metadata.Data != nil {
+		opt, err := generateWithIssuerMetadataOpt(issuerMetadata)
+		if err != nil {
+			return nil, err
+		}
+
+		opts = append(opts, opt)
+	}
+
+	if preferredLocale != "" {
+		opt := goapicredentialschema.WithPreferredLocale(preferredLocale)
+
+		opts = append(opts, opt)
+	}
+
+	return opts, nil
+}
+
+func generateWithIssuerMetadataOpt(issuerMetadata *IssuerMetadata) (goapicredentialschema.ResolveOpt, error) {
+	var issuerMetadataParsed issuer.Metadata
+
+	err := json.Unmarshal(issuerMetadata.Metadata.Data, &issuerMetadataParsed)
+	if err != nil {
+		return nil, err
+	}
+
+	opt := goapicredentialschema.WithIssuerMetadata(&issuerMetadataParsed)
+
+	return opt, nil
+}

--- a/cmd/wallet-sdk-gomobile/credentialschema/testdata/credential_university_degree.jsonld
+++ b/cmd/wallet-sdk-gomobile/credentialschema/testdata/credential_university_degree.jsonld
@@ -6,9 +6,15 @@
     "https://trustbloc.github.io/context/vc/examples-v1.jsonld"
   ],
   "id": "http://example.edu/credentials/1872",
-  "type": "VerifiableCredential",
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
   "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
+    "id": "1234",
+    "given_name": "Alice",
+    "surname": "Bowman",
+    "gpa": "4.0"
   },
   "issuer": {
     "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",

--- a/cmd/wallet-sdk-gomobile/credentialschema/testdata/issuer_metadata.json
+++ b/cmd/wallet-sdk-gomobile/credentialschema/testdata/issuer_metadata.json
@@ -1,0 +1,81 @@
+{
+  "issuer":"https://server.example.com",
+  "authorization_endpoint":"https://server.example.com/connect/authorize",
+  "token_endpoint":"http://server.example.com/connect/token",
+  "pushed_authorization_request_endpoint":"https://server.example.com/connect/par-authorize",
+  "require_pushed_authorization_requests":false,
+  "credential_endpoint":"http://server.example.com/credential",
+  "credentials_supported": [
+    {
+      "format": "jwt_vc_json",
+      "id": "UniversityDegree_JWT",
+      "types": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "did"
+      ],
+      "cryptographic_suites_supported": [
+        "ES256K"
+      ],
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "url": "https://exampleuniversity.com/public/logo.png",
+            "alternative_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "credentialSubject": {
+        "id": {
+          "display": [
+            {
+              "name": "ID",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "given_name": {
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "surname": {
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "gpa": {
+          "display": [
+            {
+              "name": "GPA",
+              "locale": "en-US"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "credential_issuer": {
+    "display": [{
+      "name": "Example University",
+      "locale": "en-US"
+    },
+      {
+        "name": "サンプル大学",
+        "locale": "jp-JA"
+      }
+    ]
+  }
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/openid4ci.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/openid4ci.go
@@ -10,6 +10,7 @@ package openid4ci
 import (
 	"encoding/json"
 
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	openid4cigoapi "github.com/trustbloc/wallet-sdk/pkg/openid4ci"
 )
 
@@ -68,8 +69,8 @@ func (i *Interaction) Authorize() (*AuthorizeResult, error) {
 	return authorizationResult, nil
 }
 
-// RequestCredential is the final step in the interaction. This is called after the wallet is authorized and is ready
-// to receive credential(s).
+// RequestCredential is the final step (or second last step, if the ResolveDisplay method isn't needed) in the
+// interaction. This is called after the wallet is authorized and is ready to receive credential(s).
 // Relevant sections of the spec:
 // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-7
 // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-8
@@ -88,4 +89,21 @@ func (i *Interaction) RequestCredential(credentialRequest *CredentialRequestOpts
 	}
 
 	return credentialResponsesBytes, nil
+}
+
+// ResolveDisplay is the optional final step that can be called after RequestCredential. It resolves display
+// information for the credentials received in this interaction. The CredentialDisplays in the returned
+// object correspond to the VCs received and are in the same order.
+func (i *Interaction) ResolveDisplay() (*api.JSONObject, error) {
+	resolvedDisplayData, err := i.goAPIInteraction.ResolveDisplay()
+	if err != nil {
+		return nil, err
+	}
+
+	resolvedDisplayDataBytes, err := json.Marshal(resolvedDisplayData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.JSONObject{Data: resolvedDisplayDataBytes}, nil
 }

--- a/pkg/credentialschema/credentialdisplay.go
+++ b/pkg/credentialschema/credentialdisplay.go
@@ -1,0 +1,216 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialschema
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+const localeNotApplicable = "N/A"
+
+func buildCredentialDisplays(vcs []*verifiable.Credential, credentialsSupported []issuer.SupportedCredential,
+	preferredLocale string,
+) ([]CredentialDisplay, error) {
+	var credentialDisplays []CredentialDisplay
+
+	for _, vc := range vcs {
+		subject, err := getSubject(vc)
+		if err != nil {
+			return nil, err
+		}
+
+		var foundMatchingType bool
+
+		for i := range credentialsSupported {
+			if haveMatchingTypes(&credentialsSupported[i], vc) {
+				credentialDisplay := buildCredentialDisplay(&credentialsSupported[i], subject, preferredLocale)
+
+				credentialDisplays = append(credentialDisplays, *credentialDisplay)
+
+				foundMatchingType = true
+
+				break
+			}
+		}
+
+		if !foundMatchingType {
+			// In case the issuer's metadata doesn't contain display info for this type of credential for some
+			// reason, we build up a default/generic type of credential display based only on information in the VC.
+			// It'll be functional, but won't be pretty.
+			credentialDisplay := buildDefaultCredentialDisplay(vc.ID, subject)
+
+			credentialDisplays = append(credentialDisplays, *credentialDisplay)
+		}
+	}
+
+	return credentialDisplays, nil
+}
+
+// The VC is considered to be a match for the supportedCredential if the VC has at least one type that's the same as
+// the type specified by the supportCredential (excluding the "VerifiableCredential" type that all VCs have).
+func haveMatchingTypes(supportedCredential *issuer.SupportedCredential, vc *verifiable.Credential) bool {
+	for _, typeFromVC := range vc.Types {
+		// We expect the types in the VC and SupportedCredential to always include VerifiableCredential,
+		// so we skip this case.
+		if strings.EqualFold(typeFromVC, "VerifiableCredential") {
+			continue
+		}
+
+		for _, typeFromSupportedCredentials := range supportedCredential.Types {
+			if strings.EqualFold(typeFromVC, typeFromSupportedCredentials) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func buildCredentialDisplay(supportedCredential *issuer.SupportedCredential, subject *verifiable.Subject,
+	preferredLocale string,
+) *CredentialDisplay {
+	resolvedClaims := resolveClaims(supportedCredential, subject, preferredLocale)
+
+	overview := *getOverviewDisplay(supportedCredential, preferredLocale)
+
+	return &CredentialDisplay{Overview: &overview, Claims: resolvedClaims}
+}
+
+func buildDefaultCredentialDisplay(vcID string, subject *verifiable.Subject) *CredentialDisplay {
+	var claims []ResolvedClaim
+
+	id := subject.ID
+
+	if id != "" {
+		claims = append(claims, ResolvedClaim{
+			Label:  "ID",
+			Value:  id,
+			Locale: localeNotApplicable,
+		})
+	}
+
+	for name, rawValue := range subject.CustomFields {
+		value := fmt.Sprintf("%v", rawValue)
+
+		claims = append(claims, ResolvedClaim{
+			Label:  name,
+			Value:  value,
+			Locale: localeNotApplicable,
+		})
+	}
+
+	credentialOverview := issuer.CredentialDisplay{Name: vcID, Locale: localeNotApplicable}
+
+	return &CredentialDisplay{Overview: &credentialOverview, Claims: claims}
+}
+
+func getSubject(vc *verifiable.Credential) (*verifiable.Subject, error) {
+	credentialSubjects, ok := vc.Subject.([]verifiable.Subject)
+	if !ok {
+		return nil, errors.New("unsupported vc subject type")
+	}
+
+	if len(credentialSubjects) != 1 {
+		return nil, errors.New("only VCs with one credential subject are supported")
+	}
+
+	return &credentialSubjects[0], nil
+}
+
+func resolveClaims(supportedCredential *issuer.SupportedCredential, credentialSubject *verifiable.Subject,
+	preferredLocale string,
+) []ResolvedClaim {
+	var resolvedClaims []ResolvedClaim
+
+	for fieldName, claim := range supportedCredential.CredentialSubject {
+		claim := claim // Resolves implicit memory aliasing warning from linter
+
+		resolvedClaim := resolveClaim(fieldName, &claim, credentialSubject, preferredLocale)
+
+		resolvedClaims = append(resolvedClaims, *resolvedClaim)
+	}
+
+	return resolvedClaims
+}
+
+func resolveClaim(fieldName string, claim *issuer.Claim, credentialSubject *verifiable.Subject,
+	preferredLocale string,
+) *ResolvedClaim {
+	if len(claim.Displays) == 0 {
+		return &ResolvedClaim{}
+	}
+
+	name, nameLocale := getLocalizedName(preferredLocale, claim)
+
+	rawValue, exists := getValue(credentialSubject, fieldName)
+	if !exists {
+		return &ResolvedClaim{
+			Label:  name,
+			Value:  "",
+			Locale: nameLocale,
+		}
+	}
+
+	value := fmt.Sprintf("%v", rawValue)
+
+	return &ResolvedClaim{
+		Label:  name,
+		Value:  value,
+		Locale: nameLocale,
+	}
+}
+
+// Returns the localized name and the actual locale used (which may differ from the user's preferred locale, depending
+// on what is available). If no preferred locale is specified, then the first available locale is used.
+func getLocalizedName(preferredLocale string, claim *issuer.Claim) (string, string) {
+	if preferredLocale == "" {
+		return claim.Displays[0].Name, claim.Displays[0].Locale
+	}
+
+	for _, claimDisplay := range claim.Displays {
+		if strings.EqualFold(preferredLocale, claimDisplay.Locale) {
+			return claimDisplay.Name, claimDisplay.Locale
+		}
+	}
+
+	return claim.Displays[0].Name, claim.Displays[0].Locale
+}
+
+func getValue(credentialSubject *verifiable.Subject, fieldName string) (interface{}, bool) {
+	if strings.EqualFold(fieldName, "ID") {
+		if credentialSubject.ID == "" {
+			return "", false
+		}
+
+		return credentialSubject.ID, true
+	}
+
+	value, exists := credentialSubject.CustomFields[fieldName]
+
+	return value, exists
+}
+
+func getOverviewDisplay(supportedCredential *issuer.SupportedCredential,
+	preferredLocale string,
+) *issuer.CredentialDisplay {
+	if preferredLocale == "" {
+		return &supportedCredential.Displays[0]
+	}
+
+	for _, credentialDisplay := range supportedCredential.Displays {
+		if strings.EqualFold(preferredLocale, credentialDisplay.Locale) {
+			return &credentialDisplay
+		}
+	}
+
+	return &supportedCredential.Displays[0]
+}

--- a/pkg/credentialschema/credentialschema.go
+++ b/pkg/credentialschema/credentialschema.go
@@ -1,0 +1,42 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package credentialschema contains a function that can be used to resolve display values per the OpenID4CI spec.
+// This implementation follows the 27 October 2022 revision of
+// https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-11.2
+package credentialschema
+
+import (
+	"fmt"
+)
+
+// Resolve resolves display information for some issued credentials based on an issuer's metadata.
+// The CredentialDisplays in the returned ResolvedDisplayData object correspond to the VCs passed in and are in the
+// same order.
+// This method requires one VC source and one issuer metadata source. See opts.go for more information.
+func Resolve(opts ...ResolveOpt) (*ResolvedDisplayData, error) {
+	vcs, metadata, preferredLocale, err := processOpts(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateCredentialsSupported(metadata.CredentialsSupported)
+	if err != nil {
+		return nil, fmt.Errorf("issuer metadata's supported credentials object is invalid: %w", err)
+	}
+
+	credentialDisplays, err := buildCredentialDisplays(vcs, metadata.CredentialsSupported, preferredLocale)
+	if err != nil {
+		return nil, err
+	}
+
+	issuerOverview := getIssuerDisplay(metadata.CredentialIssuer, preferredLocale)
+
+	return &ResolvedDisplayData{
+		IssuerDisplay:      issuerOverview,
+		CredentialDisplays: credentialDisplays,
+	}, nil
+}

--- a/pkg/credentialschema/credentialschema_test.go
+++ b/pkg/credentialschema/credentialschema_test.go
@@ -1,0 +1,411 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialschema_test
+
+import (
+	_ "embed"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/trustbloc/wallet-sdk/pkg/memstorage"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+	"github.com/piprate/json-gold/ld"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/wallet-sdk/pkg/credentialschema"
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+var (
+	//go:embed testdata/issuer_metadata.json
+	sampleIssuerMetadata []byte
+
+	//go:embed testdata/issuer_metadata_without_claims_display.json
+	issuerMetadataWithoutClaimsDisplay []byte
+
+	//go:embed testdata/credential_university_degree.jsonld
+	credentialUniversityDegree []byte
+
+	//go:embed testdata/unsupported_credential_string_subject.jsonld
+	unsupportedCredentialStringSubject []byte
+
+	//go:embed testdata/unsupported_credential_multiple_subjects.jsonld
+	unsupportedCredentialMultipleSubjects []byte
+)
+
+type mockIssuerServerHandler struct{}
+
+func (m *mockIssuerServerHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
+	_, err := writer.Write(sampleIssuerMetadata)
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		t.Run("Credentials supported object contains display info for the given VC", func(t *testing.T) {
+			credential, err := verifiable.ParseCredential(credentialUniversityDegree,
+				verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+				verifiable.WithDisabledProofCheck())
+			require.NoError(t, err)
+
+			var issuerMetadata issuer.Metadata
+
+			err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
+			require.NoError(t, err)
+
+			t.Run("Without preferred locale specified", func(t *testing.T) {
+				resolvedDisplayData, errResolve := credentialschema.Resolve(
+					credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+					credentialschema.WithIssuerMetadata(&issuerMetadata))
+				require.NoError(t, errResolve)
+
+				checkSuccessCaseMatchedDisplayData(t, resolvedDisplayData)
+			})
+			t.Run("With preferred locale specified", func(t *testing.T) {
+				t.Run("Issuer metadata has a localization for the given locale", func(t *testing.T) {
+					resolvedDisplayData, errResolve := credentialschema.Resolve(
+						credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+						credentialschema.WithIssuerMetadata(&issuerMetadata),
+						credentialschema.WithPreferredLocale("en-US"))
+					require.NoError(t, errResolve)
+
+					checkSuccessCaseMatchedDisplayData(t, resolvedDisplayData)
+				})
+				t.Run("Issuer metadata does not have a localization for the given locale", func(t *testing.T) {
+					resolvedDisplayData, errResolve := credentialschema.Resolve(
+						credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+						credentialschema.WithIssuerMetadata(&issuerMetadata),
+						credentialschema.WithPreferredLocale("UnknownLocale"))
+					require.NoError(t, errResolve)
+
+					checkSuccessCaseMatchedDisplayData(t, resolvedDisplayData)
+				})
+			})
+			t.Run("With credential reader instead of directly passing in VC", func(t *testing.T) {
+				memStorageProvider := memstorage.NewProvider()
+
+				errAdd := memStorageProvider.Add(credential)
+				require.NoError(t, errAdd)
+
+				resolvedDisplayData, errResolve := credentialschema.Resolve(
+					credentialschema.WithCredentialReader(memStorageProvider,
+						[]string{"http://example.edu/credentials/1872"}),
+					credentialschema.WithIssuerMetadata(&issuerMetadata),
+					credentialschema.WithPreferredLocale("en-US"))
+				require.NoError(t, errResolve)
+
+				checkSuccessCaseMatchedDisplayData(t, resolvedDisplayData)
+			})
+			t.Run("With issuer URI instead of directly passing in issuer metadata", func(t *testing.T) {
+				issuerServerHandler := &mockIssuerServerHandler{}
+				server := httptest.NewServer(issuerServerHandler)
+
+				defer server.Close()
+
+				resolvedDisplayData, errResolve := credentialschema.Resolve(
+					credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+					credentialschema.WithIssuerURI(server.URL))
+				require.NoError(t, errResolve)
+
+				checkSuccessCaseMatchedDisplayData(t, resolvedDisplayData)
+			})
+			t.Run("Credentials supported object does not contain display info for the given VC, "+
+				"resulting in the default display being used", func(t *testing.T) {
+				var issuerMetadata issuer.Metadata
+
+				err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
+				require.NoError(t, err)
+
+				issuerMetadata.CredentialsSupported[0].Types[1] = "SomeOtherType"
+
+				resolvedDisplayData, errResolve := credentialschema.Resolve(
+					credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+					credentialschema.WithIssuerMetadata(&issuerMetadata),
+					credentialschema.WithPreferredLocale("en-US"))
+				require.NoError(t, errResolve)
+				require.Equal(t, "Example University", resolvedDisplayData.IssuerDisplay.Name)
+				require.Equal(t, "en-US", resolvedDisplayData.IssuerDisplay.Locale)
+				require.Len(t, resolvedDisplayData.CredentialDisplays, 1)
+				require.Equal(t, "http://example.edu/credentials/1872",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Name)
+				require.Equal(t, "N/A",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Locale)
+				require.Nil(t, resolvedDisplayData.CredentialDisplays[0].Overview.Logo)
+				require.Empty(t, resolvedDisplayData.CredentialDisplays[0].Overview.BackgroundColor)
+				require.Empty(t, resolvedDisplayData.CredentialDisplays[0].Overview.TextColor)
+
+				expectedClaims := []credentialschema.ResolvedClaim{
+					{Label: "ID", Value: "1234", Locale: "N/A"},
+					{Label: "given_name", Value: "Alice", Locale: "N/A"},
+					{Label: "surname", Value: "Bowman", Locale: "N/A"},
+					{Label: "gpa", Value: "4.0", Locale: "N/A"},
+				}
+
+				verifyClaimsAnyOrder(t, resolvedDisplayData.CredentialDisplays[0].Claims, expectedClaims)
+			})
+			t.Run("Credentials supported object does not have claim display info", func(t *testing.T) {
+				var issuerMetadata issuer.Metadata
+
+				err = json.Unmarshal(issuerMetadataWithoutClaimsDisplay, &issuerMetadata)
+				require.NoError(t, err)
+
+				resolvedDisplayData, errResolve := credentialschema.Resolve(
+					credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+					credentialschema.WithIssuerMetadata(&issuerMetadata),
+					credentialschema.WithPreferredLocale("en-US"))
+				require.NoError(t, errResolve)
+				require.Equal(t, "Example University", resolvedDisplayData.IssuerDisplay.Name)
+				require.Equal(t, "en-US", resolvedDisplayData.IssuerDisplay.Locale)
+				require.Len(t, resolvedDisplayData.CredentialDisplays, 1)
+				require.Equal(t, "University Credential",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Name)
+				require.Equal(t, "en-US",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Locale)
+				require.Equal(t, "https://exampleuniversity.com/public/logo.png",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Logo.URL)
+				require.Empty(t, resolvedDisplayData.CredentialDisplays[0].Overview.Logo.AltText)
+				require.Equal(t, "#12107c", resolvedDisplayData.CredentialDisplays[0].Overview.BackgroundColor)
+				require.Equal(t, "#FFFFFF", resolvedDisplayData.CredentialDisplays[0].Overview.TextColor)
+				require.Len(t, resolvedDisplayData.CredentialDisplays[0].Claims, 1)
+				require.Empty(t, resolvedDisplayData.CredentialDisplays[0].Claims[0])
+			})
+			t.Run("Issuer metadata does not have the optional issuer display info", func(t *testing.T) {
+				var issuerMetadata issuer.Metadata
+
+				err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
+				require.NoError(t, err)
+
+				issuerMetadata.CredentialIssuer = nil
+
+				resolvedDisplayData, err := credentialschema.Resolve(
+					credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+					credentialschema.WithIssuerMetadata(&issuerMetadata))
+				require.NoError(t, err)
+
+				require.Nil(t, resolvedDisplayData.IssuerDisplay)
+				require.Len(t, resolvedDisplayData.CredentialDisplays, 1)
+				require.Equal(t, "University Credential",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Name)
+				require.Equal(t, "en-US",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Locale)
+				require.Equal(t, "https://exampleuniversity.com/public/logo.png",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Logo.URL)
+				require.Empty(t, resolvedDisplayData.CredentialDisplays[0].Overview.Logo.AltText)
+				require.Equal(t, "#12107c", resolvedDisplayData.CredentialDisplays[0].Overview.BackgroundColor)
+				require.Equal(t, "#FFFFFF", resolvedDisplayData.CredentialDisplays[0].Overview.TextColor)
+
+				expectedClaims := []credentialschema.ResolvedClaim{
+					{Label: "ID", Value: "1234", Locale: "en-US"},
+					{Label: "Given Name", Value: "Alice", Locale: "en-US"},
+					{Label: "Surname", Value: "Bowman", Locale: "en-US"},
+					{Label: "GPA", Value: "4.0", Locale: "en-US"},
+				}
+
+				verifyClaimsAnyOrder(t, resolvedDisplayData.CredentialDisplays[0].Claims, expectedClaims)
+			})
+			t.Run("VC does not have the subject fields specified by the claim display info", func(t *testing.T) {
+				credential, err := verifiable.ParseCredential(credentialUniversityDegree,
+					verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+					verifiable.WithDisabledProofCheck())
+				require.NoError(t, err)
+
+				credential.Subject = []verifiable.Subject{
+					{
+						ID:           "",
+						CustomFields: nil,
+					},
+				}
+
+				var issuerMetadata issuer.Metadata
+
+				err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
+				require.NoError(t, err)
+
+				resolvedDisplayData, err := credentialschema.Resolve(
+					credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+					credentialschema.WithIssuerMetadata(&issuerMetadata))
+				require.NoError(t, err)
+
+				require.Equal(t, "Example University", resolvedDisplayData.IssuerDisplay.Name)
+				require.Equal(t, "en-US", resolvedDisplayData.IssuerDisplay.Locale)
+				require.Len(t, resolvedDisplayData.CredentialDisplays, 1)
+				require.Equal(t, "University Credential",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Name)
+				require.Equal(t, "en-US",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Locale)
+				require.Equal(t, "https://exampleuniversity.com/public/logo.png",
+					resolvedDisplayData.CredentialDisplays[0].Overview.Logo.URL)
+				require.Empty(t, resolvedDisplayData.CredentialDisplays[0].Overview.Logo.AltText)
+				require.Equal(t, "#12107c", resolvedDisplayData.CredentialDisplays[0].Overview.BackgroundColor)
+				require.Equal(t, "#FFFFFF", resolvedDisplayData.CredentialDisplays[0].Overview.TextColor)
+
+				expectedClaims := []credentialschema.ResolvedClaim{
+					{Label: "ID", Value: "", Locale: "en-US"},
+					{Label: "Given Name", Value: "", Locale: "en-US"},
+					{Label: "Surname", Value: "", Locale: "en-US"},
+					{Label: "GPA", Value: "", Locale: "en-US"},
+				}
+
+				verifyClaimsAnyOrder(t, resolvedDisplayData.CredentialDisplays[0].Claims, expectedClaims)
+			})
+		})
+	})
+	t.Run("Invalid options:", func(t *testing.T) {
+		t.Run("No credentials specified", func(t *testing.T) {
+			resolvedDisplayData, err := credentialschema.Resolve()
+			require.EqualError(t, err, "no credentials specified")
+			require.Nil(t, resolvedDisplayData)
+		})
+		t.Run("Multiple credential sources", func(t *testing.T) {
+			resolvedDisplayData, err := credentialschema.Resolve(
+				credentialschema.WithCredentials([]*verifiable.Credential{{}}),
+				credentialschema.WithCredentialReader(memstorage.NewProvider(), []string{}))
+			require.EqualError(t, err, "cannot have multiple credential sources specified - "+
+				"must use either WithCredentials or WithCredentialReader, but not both")
+			require.Nil(t, resolvedDisplayData)
+		})
+		t.Run("Using credential reader, but no IDs specified", func(t *testing.T) {
+			resolvedDisplayData, err := credentialschema.Resolve(
+				credentialschema.WithCredentialReader(memstorage.NewProvider(), []string{}))
+			require.EqualError(t, err, "credential IDs must be provided when using a credential reader")
+			require.Nil(t, resolvedDisplayData)
+		})
+		t.Run("Using credential reader, but credential could not be found", func(t *testing.T) {
+			resolvedDisplayData, err := credentialschema.Resolve(
+				credentialschema.WithCredentialReader(memstorage.NewProvider(), []string{"SomeID"}),
+				credentialschema.WithIssuerMetadata(&issuer.Metadata{}))
+			require.EqualError(t, err, "no credential with an id of SomeID was found")
+			require.Nil(t, resolvedDisplayData)
+		})
+		t.Run("No issuer metadata source specified", func(t *testing.T) {
+			resolvedDisplayData, err := credentialschema.Resolve(
+				credentialschema.WithCredentials([]*verifiable.Credential{{}}))
+			require.EqualError(t, err, "no issuer metadata source specified")
+			require.Nil(t, resolvedDisplayData)
+		})
+		t.Run("Using issuer URI option, but failed to fetch issuer metadata", func(t *testing.T) {
+			resolvedDisplayData, err := credentialschema.Resolve(
+				credentialschema.WithCredentials([]*verifiable.Credential{{}}),
+				credentialschema.WithIssuerURI("http://BadURL"))
+			require.Contains(t, err.Error(), `Get "http://BadURL/.well-known/openid-configuration":`+
+				` dial tcp: lookup BadURL:`)
+			require.Nil(t, resolvedDisplayData)
+		})
+	})
+	t.Run("Invalid supported credentials object", func(t *testing.T) {
+		metadata := issuer.Metadata{
+			CredentialsSupported: []issuer.SupportedCredential{{ID: "SomeID"}, {ID: "SomeID"}},
+		}
+
+		resolvedDisplayData, err := credentialschema.Resolve(
+			credentialschema.WithCredentials([]*verifiable.Credential{{}}),
+			credentialschema.WithIssuerMetadata(&metadata))
+		require.EqualError(t, err, "issuer metadata's supported credentials object is invalid: "+
+			"the ID SomeID appears in multiple supported credential objects")
+		require.Nil(t, resolvedDisplayData)
+	})
+	t.Run("Unsupported VC", func(t *testing.T) {
+		t.Run("Unsupported subject type", func(t *testing.T) {
+			credential, err := verifiable.ParseCredential(unsupportedCredentialStringSubject,
+				verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+				verifiable.WithDisabledProofCheck())
+			require.NoError(t, err)
+
+			var issuerMetadata issuer.Metadata
+
+			err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
+			require.NoError(t, err)
+
+			resolvedDisplayData, err := credentialschema.Resolve(
+				credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+				credentialschema.WithIssuerMetadata(&issuerMetadata))
+			require.EqualError(t, err, "unsupported vc subject type")
+			require.Nil(t, resolvedDisplayData)
+		})
+		t.Run("Multiple subjects", func(t *testing.T) {
+			credential, err := verifiable.ParseCredential(unsupportedCredentialMultipleSubjects,
+				verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+				verifiable.WithDisabledProofCheck())
+			require.NoError(t, err)
+
+			var issuerMetadata issuer.Metadata
+
+			err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
+			require.NoError(t, err)
+
+			resolvedDisplayData, err := credentialschema.Resolve(
+				credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+				credentialschema.WithIssuerMetadata(&issuerMetadata))
+			require.EqualError(t, err, "only VCs with one credential subject are supported")
+			require.Nil(t, resolvedDisplayData)
+		})
+	})
+}
+
+func checkSuccessCaseMatchedDisplayData(t *testing.T, resolvedDisplayData *credentialschema.ResolvedDisplayData) {
+	t.Helper()
+
+	require.Equal(t, "Example University", resolvedDisplayData.IssuerDisplay.Name)
+	require.Equal(t, "en-US", resolvedDisplayData.IssuerDisplay.Locale)
+	require.Len(t, resolvedDisplayData.CredentialDisplays, 1)
+	require.Equal(t, "University Credential",
+		resolvedDisplayData.CredentialDisplays[0].Overview.Name)
+	require.Equal(t, "en-US",
+		resolvedDisplayData.CredentialDisplays[0].Overview.Locale)
+	require.Equal(t, "https://exampleuniversity.com/public/logo.png",
+		resolvedDisplayData.CredentialDisplays[0].Overview.Logo.URL)
+	require.Empty(t, resolvedDisplayData.CredentialDisplays[0].Overview.Logo.AltText)
+	require.Equal(t, "#12107c", resolvedDisplayData.CredentialDisplays[0].Overview.BackgroundColor)
+	require.Equal(t, "#FFFFFF", resolvedDisplayData.CredentialDisplays[0].Overview.TextColor)
+
+	expectedClaims := []credentialschema.ResolvedClaim{
+		{Label: "ID", Value: "1234", Locale: "en-US"},
+		{Label: "Given Name", Value: "Alice", Locale: "en-US"},
+		{Label: "Surname", Value: "Bowman", Locale: "en-US"},
+		{Label: "GPA", Value: "4.0", Locale: "en-US"},
+	}
+
+	verifyClaimsAnyOrder(t, resolvedDisplayData.CredentialDisplays[0].Claims, expectedClaims)
+}
+
+func verifyClaimsAnyOrder(t *testing.T, actualClaims []credentialschema.ResolvedClaim,
+	expectedClaims []credentialschema.ResolvedClaim,
+) {
+	t.Helper()
+
+	require.Len(t, actualClaims, len(expectedClaims), "expected (in any order): [%v]", expectedClaims)
+
+	claimsMatched := make([]bool, len(expectedClaims))
+
+	for _, actualClaim := range actualClaims {
+		for j, expectedClaim := range expectedClaims {
+			if claimsMatched[j] {
+				continue
+			}
+
+			if actualClaim.Label == expectedClaim.Label &&
+				actualClaim.Value == expectedClaim.Value &&
+				actualClaim.Locale == expectedClaim.Locale {
+				claimsMatched[j] = true
+
+				break
+			}
+		}
+	}
+
+	for _, claimMatched := range claimsMatched {
+		if !claimMatched {
+			require.FailNow(t, "received unexpected claims",
+				"actual: [%v] expected (in any order): [%v]", actualClaims, expectedClaims)
+		}
+	}
+}

--- a/pkg/credentialschema/credentialssupported.go
+++ b/pkg/credentialschema/credentialssupported.go
@@ -1,0 +1,28 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialschema
+
+import (
+	"fmt"
+
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+func validateCredentialsSupported(credentialsSupported []issuer.SupportedCredential) error {
+	allSupportedCredentialObjectIDs := make(map[string]struct{})
+
+	for i := range credentialsSupported {
+		_, duplicateIDFound := allSupportedCredentialObjectIDs[credentialsSupported[i].ID]
+		if duplicateIDFound {
+			return fmt.Errorf("the ID %s appears in multiple supported credential objects", credentialsSupported[i].ID)
+		}
+
+		allSupportedCredentialObjectIDs[credentialsSupported[i].ID] = struct{}{}
+	}
+
+	return nil
+}

--- a/pkg/credentialschema/issuerdisplay.go
+++ b/pkg/credentialschema/issuerdisplay.go
@@ -1,0 +1,42 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialschema
+
+import (
+	"strings"
+
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+func getIssuerDisplay(credentialIssuer *issuer.CredentialIssuer,
+	locale string,
+) *ResolvedCredentialIssuerDisplay {
+	if credentialIssuer == nil || len(credentialIssuer.Displays) == 0 {
+		return nil
+	}
+
+	if locale == "" {
+		return &ResolvedCredentialIssuerDisplay{
+			Name:   credentialIssuer.Displays[0].Name,
+			Locale: credentialIssuer.Displays[0].Locale,
+		}
+	}
+
+	for _, issuerDisplay := range credentialIssuer.Displays {
+		if strings.EqualFold(issuerDisplay.Locale, locale) {
+			return &ResolvedCredentialIssuerDisplay{
+				Name:   issuerDisplay.Name,
+				Locale: issuerDisplay.Locale,
+			}
+		}
+	}
+
+	return &ResolvedCredentialIssuerDisplay{
+		Name:   credentialIssuer.Displays[0].Name,
+		Locale: credentialIssuer.Displays[0].Locale,
+	}
+}

--- a/pkg/credentialschema/models.go
+++ b/pkg/credentialschema/models.go
@@ -1,0 +1,37 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialschema
+
+import (
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+// ResolvedDisplayData represents display information for some issued credentials based on an issuer's metadata.
+type ResolvedDisplayData struct {
+	IssuerDisplay      *ResolvedCredentialIssuerDisplay `json:"issuer_display,omitempty"`
+	CredentialDisplays []CredentialDisplay              `json:"credential_displays,omitempty"`
+}
+
+// ResolvedCredentialIssuerDisplay represents display information about the issuer of some credential(s).
+type ResolvedCredentialIssuerDisplay struct {
+	Name   string `json:"name,omitempty"`
+	Locale string `json:"locale,omitempty"`
+}
+
+// CredentialDisplay represents display data for a credential.
+// Display data for specific claims (e.g. first name, date of birth, etc.) are in Claims.
+type CredentialDisplay struct {
+	Overview *issuer.CredentialDisplay `json:"overview,omitempty"`
+	Claims   []ResolvedClaim           `json:"claims,omitempty"`
+}
+
+// ResolvedClaim represents display data for a specific claim.
+type ResolvedClaim struct {
+	Label  string `json:"label,omitempty"`
+	Value  string `json:"value,omitempty"`
+	Locale string `json:"locale,omitempty"`
+}

--- a/pkg/credentialschema/opts.go
+++ b/pkg/credentialschema/opts.go
@@ -1,0 +1,196 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package credentialschema
+
+import (
+	"errors"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
+
+	metadatafetcher "github.com/trustbloc/wallet-sdk/pkg/internal/issuermetadata"
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+// credentialSource represents the different ways that credentials can be passed in to the Resolve function.
+// At most one out of vcs and reader can be used for a given call to Resolve.
+// If reader is specified, then ids must also be specified. The corresponding credentials will be
+// retrieved from the credentialReader.
+type credentialSource struct {
+	// vcs is a slice of Verifiable Credentials.
+	vcs []*verifiable.Credential
+	// reader allows for access to VCs stored via some storage mechanism.
+	reader credentialReader
+	// ids specifies which credentials should be retrieved from the reader.
+	ids []string
+}
+
+// issuerMetadataSource represents the different ways that issuer metadata can be specified in the Resolve function.
+// At most one out of issuerURI and metadata can be used for a given call to Resolve.
+// Setting issuerURI will cause the Resolve function to fetch an issuer's metadata by doing a lookup on its
+// OpenID configuration endpoint. issuerURI is expected to be the base URL for the issuer.
+// Alternatively, if metadata is set, then it will be used directly.
+type issuerMetadataSource struct {
+	issuerURI string
+	metadata  *issuer.Metadata
+}
+
+type resolveOpts struct {
+	credentialSource     credentialSource
+	issuerMetadataSource issuerMetadataSource
+	preferredLocal       string
+}
+
+// ResolveOpt represents an option for the Resolve function.
+type ResolveOpt func(opts *resolveOpts)
+
+// WithCredentials is an option allowing a caller to directly pass in the VCs that they want to have resolved.
+func WithCredentials(vcs []*verifiable.Credential) ResolveOpt {
+	return func(opts *resolveOpts) {
+		opts.credentialSource.vcs = vcs
+	}
+}
+
+// A credentialReader is capable of reading VCs from some underlying storage mechanism.
+type credentialReader interface {
+	// Get retrieves a VC.
+	Get(id string) (*verifiable.Credential, error)
+}
+
+// WithCredentialReader is an option allowing a caller to specify the VCs they want to have resolved by providing their
+// IDs along with a CredentialReader.
+func WithCredentialReader(credentialReader credentialReader, ids []string) ResolveOpt {
+	return func(opts *resolveOpts) {
+		opts.credentialSource.reader = credentialReader
+		opts.credentialSource.ids = ids
+	}
+}
+
+// WithIssuerURI is an option allowing a caller to specify an issuer URI that will be used to fetch metadata. Using this
+// option will cause the Resolve function to fetch an issuer's metadata by doing a lookup on its OpenID configuration
+// endpoint. The issuer URI is expected to be the base URL for the issuer.
+func WithIssuerURI(uri string) ResolveOpt {
+	return func(opts *resolveOpts) {
+		opts.issuerMetadataSource.issuerURI = uri
+	}
+}
+
+// WithIssuerMetadata is an option allowing a caller to directly pass in the issuer's metadata to use for resolving VCs.
+func WithIssuerMetadata(metadata *issuer.Metadata) ResolveOpt {
+	return func(opts *resolveOpts) {
+		opts.issuerMetadataSource.metadata = metadata
+	}
+}
+
+// WithPreferredLocale is an option specifying the caller's preferred locale to look for when resolving VCs.
+// If not specified, or the user's preferred locale is not available, then the first locale specified by the
+// issuer's metadata will be used during resolution.
+// The actual locales used for various pieces of display information are available in the ResolvedDisplayData object.
+func WithPreferredLocale(locale string) ResolveOpt {
+	return func(opts *resolveOpts) {
+		opts.preferredLocal = locale
+	}
+}
+
+func processOpts(opts []ResolveOpt) ([]*verifiable.Credential, *issuer.Metadata, string, error) {
+	mergedOpts := mergeOpts(opts)
+
+	err := validateOpts(mergedOpts)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return processValidatedOpts(mergedOpts)
+}
+
+func mergeOpts(opts []ResolveOpt) *resolveOpts {
+	resolveOpts := &resolveOpts{}
+	for _, opt := range opts {
+		opt(resolveOpts)
+	}
+
+	return resolveOpts
+}
+
+func validateOpts(opts *resolveOpts) error {
+	err := validateVCOpts(&opts.credentialSource)
+	if err != nil {
+		return err
+	}
+
+	return validateIssuerMetadataOpts(&opts.issuerMetadataSource)
+}
+
+func validateVCOpts(credentialSource *credentialSource) error {
+	if credentialSource.vcs == nil && credentialSource.reader == nil {
+		return errors.New("no credentials specified")
+	}
+
+	if credentialSource.vcs != nil && credentialSource.reader != nil {
+		return errors.New("cannot have multiple credential sources specified - must use either " +
+			"WithCredentials or WithCredentialReader, but not both")
+	}
+
+	if credentialSource.reader != nil && len(credentialSource.ids) == 0 {
+		return errors.New("credential IDs must be provided when using a credential reader")
+	}
+
+	return nil
+}
+
+func validateIssuerMetadataOpts(issuerMetadataSource *issuerMetadataSource) error {
+	if issuerMetadataSource.issuerURI == "" && issuerMetadataSource.metadata == nil {
+		return errors.New("no issuer metadata source specified")
+	}
+
+	return nil
+}
+
+func processValidatedOpts(opts *resolveOpts) ([]*verifiable.Credential, *issuer.Metadata, string, error) {
+	vcs, err := processVCOpts(&opts.credentialSource)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	issuerMetadata, err := processIssuerMetadataOpts(&opts.issuerMetadataSource)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return vcs, issuerMetadata, opts.preferredLocal, nil
+}
+
+func processVCOpts(credentialSource *credentialSource) ([]*verifiable.Credential, error) {
+	var vcs []*verifiable.Credential
+
+	if credentialSource.vcs != nil {
+		vcs = credentialSource.vcs
+	} else {
+		for _, id := range credentialSource.ids {
+			vc, err := credentialSource.reader.Get(id)
+			if err != nil {
+				return nil, err
+			}
+
+			vcs = append(vcs, vc)
+		}
+	}
+
+	return vcs, nil
+}
+
+func processIssuerMetadataOpts(issuerMetadataSource *issuerMetadataSource) (*issuer.Metadata, error) {
+	if issuerMetadataSource.metadata != nil {
+		return issuerMetadataSource.metadata, nil
+	}
+
+	metadata, err := metadatafetcher.Get(issuerMetadataSource.issuerURI)
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata, nil
+}

--- a/pkg/credentialschema/testdata/credential_university_degree.jsonld
+++ b/pkg/credentialschema/testdata/credential_university_degree.jsonld
@@ -6,9 +6,15 @@
     "https://trustbloc.github.io/context/vc/examples-v1.jsonld"
   ],
   "id": "http://example.edu/credentials/1872",
-  "type": "VerifiableCredential",
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
   "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
+    "id": "1234",
+    "given_name": "Alice",
+    "surname": "Bowman",
+    "gpa": "4.0"
   },
   "issuer": {
     "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",

--- a/pkg/credentialschema/testdata/issuer_metadata.json
+++ b/pkg/credentialschema/testdata/issuer_metadata.json
@@ -1,0 +1,81 @@
+{
+  "issuer":"https://server.example.com",
+  "authorization_endpoint":"https://server.example.com/connect/authorize",
+  "token_endpoint":"http://server.example.com/connect/token",
+  "pushed_authorization_request_endpoint":"https://server.example.com/connect/par-authorize",
+  "require_pushed_authorization_requests":false,
+  "credential_endpoint":"http://server.example.com/credential",
+  "credentials_supported": [
+    {
+      "format": "jwt_vc_json",
+      "id": "UniversityDegree_JWT",
+      "types": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "did"
+      ],
+      "cryptographic_suites_supported": [
+        "ES256K"
+      ],
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "url": "https://exampleuniversity.com/public/logo.png",
+            "alternative_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "credentialSubject": {
+        "id": {
+          "display": [
+            {
+              "name": "ID",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "given_name": {
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "surname": {
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "gpa": {
+          "display": [
+            {
+              "name": "GPA",
+              "locale": "en-US"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "credential_issuer": {
+    "display": [{
+      "name": "Example University",
+      "locale": "en-US"
+    },
+      {
+        "name": "サンプル大学",
+        "locale": "jp-JA"
+      }
+    ]
+  }
+}

--- a/pkg/credentialschema/testdata/issuer_metadata_without_claims_display.json
+++ b/pkg/credentialschema/testdata/issuer_metadata_without_claims_display.json
@@ -1,0 +1,50 @@
+{
+  "issuer":"https://server.example.com",
+  "authorization_endpoint":"https://server.example.com/connect/authorize",
+  "token_endpoint":"http://server.example.com/connect/token",
+  "pushed_authorization_request_endpoint":"https://server.example.com/connect/par-authorize",
+  "require_pushed_authorization_requests":false,
+  "credential_endpoint":"http://server.example.com/credential",
+  "credentials_supported": [
+    {
+      "format": "jwt_vc_json",
+      "id": "UniversityDegree_JWT",
+      "types": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "did"
+      ],
+      "cryptographic_suites_supported": [
+        "ES256K"
+      ],
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "url": "https://exampleuniversity.com/public/logo.png",
+            "alternative_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "credentialSubject": {
+        "id": {}
+      }
+    }
+  ],
+  "credential_issuer": {
+    "display": [{
+      "name": "Example University",
+      "locale": "en-US"
+    },
+      {
+        "name": "サンプル大学",
+        "locale": "jp-JA"
+      }
+    ]
+  }
+}

--- a/pkg/credentialschema/testdata/unsupported_credential_multiple_subjects.jsonld
+++ b/pkg/credentialschema/testdata/unsupported_credential_multiple_subjects.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context":[
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "id":"http://example.edu/credentials/1872",
+  "type":[
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "credentialSubject":[
+    {
+      "given_name":"Alice",
+      "surname":"Bowman",
+      "gpa":"4.0"
+    },
+    {
+      "given_name":"Alice2",
+      "surname":"Bowman2",
+      "gpa":"4.0"
+    }
+  ],
+  "issuer":{
+    "id":"did:example:76e12ec712ebc6f1c221ebfeb1f",
+    "name":"Example University",
+    "image":"data:image/png;base64,iVBOR"
+  },
+  "issuanceDate":"2010-01-01T19:23:24Z"
+}

--- a/pkg/credentialschema/testdata/unsupported_credential_string_subject.jsonld
+++ b/pkg/credentialschema/testdata/unsupported_credential_string_subject.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "id": "http://example.edu/credentials/1872",
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
+  "credentialSubject": "SomeString",
+  "issuer": {
+    "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
+    "name": "Example University",
+    "image": "data:image/png;base64,iVBOR"
+  },
+  "issuanceDate": "2010-01-01T19:23:24Z"
+}

--- a/pkg/internal/issuermetadata/issuermetadata.go
+++ b/pkg/internal/issuermetadata/issuermetadata.go
@@ -1,0 +1,56 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package issuermetadata contains a function for fetching issuer metadata.
+package issuermetadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+// Get gets an issuer's metadata by doing a lookup on its OpenID configuration endpoint.
+// issuerURI is expected to be the base URL for the issuer.
+func Get(issuerURI string) (*issuer.Metadata, error) {
+	metadataEndpoint := issuerURI + "/.well-known/openid-configuration"
+
+	// TODO: Implement trusted list type of mechanism? The gosec warning (correctly) warns about using a variable URL.
+	response, err := http.Get(metadataEndpoint) //nolint: noctx,gosec // TODO: To be re-evaluated later
+	if err != nil {
+		return nil, err
+	}
+
+	responseBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received status code [%d] with body [%s] from issuer's "+
+			"OpenID configuration endpoint", response.StatusCode, string(responseBytes))
+	}
+
+	defer func() {
+		errClose := response.Body.Close()
+		if errClose != nil {
+			println(fmt.Sprintf("failed to close response body: %s", errClose.Error()))
+		}
+	}()
+
+	var metadata issuer.Metadata
+
+	err = json.Unmarshal(responseBytes, &metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response from the issuer's "+
+			"OpenID configuration endpoint: %w", err)
+	}
+
+	return &metadata, err
+}

--- a/pkg/internal/issuermetadata/issuermetadata_test.go
+++ b/pkg/internal/issuermetadata/issuermetadata_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issuermetadata_test
+
+import (
+	_ "embed"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/wallet-sdk/pkg/internal/issuermetadata"
+)
+
+//go:embed testdata/sample_issuer_metadata.json
+var sampleIssuerMetadata string
+
+type mockIssuerServerHandler struct {
+	issuerMetadata            string
+	metadataRequestShouldFail bool
+}
+
+func (m *mockIssuerServerHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
+	var err error
+
+	if m.metadataRequestShouldFail {
+		writer.WriteHeader(http.StatusInternalServerError)
+		_, err = writer.Write([]byte("test failure"))
+	} else {
+		_, err = writer.Write([]byte(m.issuerMetadata))
+	}
+
+	if err != nil {
+		println(err.Error())
+	}
+}
+
+func TestGet(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		issuerServerHandler := &mockIssuerServerHandler{issuerMetadata: sampleIssuerMetadata}
+		server := httptest.NewServer(issuerServerHandler)
+
+		defer server.Close()
+
+		issuerMetadata, err := issuermetadata.Get(server.URL)
+		require.NoError(t, err)
+		require.NotNil(t, issuerMetadata)
+	})
+	t.Run("Fail to reach issuer OpenID config endpoint", func(t *testing.T) {
+		issuerMetadata, err := issuermetadata.Get("http://BadURL")
+		require.Contains(t, err.Error(), `Get "http://BadURL/.well-known/openid-configuration":`+
+			` dial tcp: lookup BadURL:`)
+		require.Nil(t, issuerMetadata)
+	})
+	t.Run("Fail to get issuer metadata: server error", func(t *testing.T) {
+		issuerServerHandler := &mockIssuerServerHandler{metadataRequestShouldFail: true}
+		server := httptest.NewServer(issuerServerHandler)
+
+		defer server.Close()
+
+		issuerMetadata, err := issuermetadata.Get(server.URL)
+		require.Contains(t, err.Error(), "received status code [500] with body [test failure] from "+
+			"issuer's OpenID configuration endpoint")
+		require.Nil(t, issuerMetadata)
+	})
+	t.Run("Fail to unmarshal response from issuer OpenID config endpoint", func(t *testing.T) {
+		issuerServerHandler := &mockIssuerServerHandler{issuerMetadata: "invalid"}
+		server := httptest.NewServer(issuerServerHandler)
+
+		defer server.Close()
+
+		issuerMetadata, err := issuermetadata.Get(server.URL)
+		require.Contains(t, err.Error(), "failed to unmarshal response from the issuer's OpenID "+
+			"configuration endpoint: invalid character 'i' looking for beginning of value")
+		require.Nil(t, issuerMetadata)
+	})
+}

--- a/pkg/internal/issuermetadata/testdata/sample_issuer_metadata.json
+++ b/pkg/internal/issuermetadata/testdata/sample_issuer_metadata.json
@@ -1,0 +1,72 @@
+{
+  "issuer":"https://server.example.com",
+  "authorization_endpoint":"https://server.example.com/connect/authorize",
+  "token_endpoint":"http://server.example.com/connect/token",
+  "pushed_authorization_request_endpoint":"https://server.example.com/connect/par-authorize",
+  "require_pushed_authorization_requests":false,
+  "credential_endpoint":"http://server.example.com/credential",
+  "credentials_supported": [
+    {
+      "format": "jwt_vc_json",
+      "id": "UniversityDegree_JWT",
+      "types": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "did"
+      ],
+      "cryptographic_suites_supported": [
+        "ES256K"
+      ],
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "url": "https://exampleuniversity.com/public/logo.png",
+            "alternative_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "credentialSubject": {
+        "given_name": {
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "surname": {
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "gpa": {
+          "display": [
+            {
+              "name": "GPA"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "credential_issuer": {
+    "display": [{
+      "name": "Example University",
+      "locale": "en-US"
+    },
+      {
+        "name": "サンプル大学",
+        "locale": "jp-JA"
+      }
+    ]
+  }
+}

--- a/pkg/memstorage/memstorage_test.go
+++ b/pkg/memstorage/memstorage_test.go
@@ -49,8 +49,11 @@ func TestProvider(t *testing.T) {
 	retrievedVCs, err := provider.GetAll()
 	require.NoError(t, err)
 	require.Len(t, retrievedVCs, 2)
-	require.Equal(t, vcToStore1.ID, retrievedVCs[0].ID)
-	require.Equal(t, vcToStore2.ID, retrievedVCs[1].ID)
+
+	gotExpectedVCsOrder1 := vcToStore1.ID == retrievedVCs[0].ID && vcToStore2.ID == retrievedVCs[1].ID
+	gotExpectedVCsOrder2 := vcToStore1.ID == retrievedVCs[1].ID && vcToStore2.ID == retrievedVCs[0].ID
+
+	require.True(t, gotExpectedVCsOrder1 || gotExpectedVCsOrder2)
 
 	// Remove one of the VCs and verify that it's deleted.
 	err = provider.Remove(vcToStore1.ID)

--- a/pkg/models/issuer/metadata.go
+++ b/pkg/models/issuer/metadata.go
@@ -1,0 +1,73 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package issuer contains models for representing an issuer's metadata.
+package issuer
+
+// Metadata represents metadata about an issuer as obtained from their .well-known OpenID configuration.
+type Metadata struct {
+	Issuer                             string                `json:"issuer,omitempty"`
+	AuthorizationEndpoint              string                `json:"authorization_endpoint,omitempty"`
+	TokenEndpoint                      string                `json:"token_endpoint,omitempty"`
+	PushedAuthorizationRequestEndpoint string                `json:"pushed_authorization_request_endpoint,omitempty"`
+	RequirePushedAuthorizationRequests bool                  `json:"require_pushed_authorization_requests,omitempty"`
+	CredentialEndpoint                 string                `json:"credential_endpoint,omitempty"`
+	CredentialsSupported               []SupportedCredential `json:"credentials_supported,omitempty"`
+	CredentialIssuer                   *CredentialIssuer     `json:"credential_issuer,omitempty"`
+}
+
+// SupportedCredential represents metadata about a credential type that a credential issuer can issue.
+type SupportedCredential struct {
+	Format                                string              `json:"format,omitempty"`
+	ID                                    string              `json:"id,omitempty"`
+	Types                                 []string            `json:"types,omitempty"`
+	CryptographicBindingsMethodsSupported []string            `json:"cryptographic_bindings_methods_supported,omitempty"`
+	CryptographicSuitesSupported          []string            `json:"cryptographic_suites_supported,omitempty"`
+	Displays                              []CredentialDisplay `json:"display,omitempty"`
+	CredentialSubject                     map[string]Claim    `json:"credentialSubject,omitempty"`
+}
+
+// CredentialDisplay represents display data for a credential as a whole.
+// Display data for specific claims (e.g. first name, date of birth, etc) are represented by ClaimDisplays, which
+// are in SupportedCredential.CredentialSubject (in the parent object above).
+type CredentialDisplay struct {
+	Name            string `json:"name,omitempty"`
+	Locale          string `json:"locale,omitempty"`
+	Logo            *Logo  `json:"logo,omitempty"`
+	BackgroundColor string `json:"background_color,omitempty"`
+	TextColor       string `json:"text_color,omitempty"`
+}
+
+// Claim represents display data for a specific claim in (potentially) multiple locales.
+// Each ClaimDisplay represents display data for a single locale.
+type Claim struct {
+	Displays []ClaimDisplay `json:"display,omitempty"`
+}
+
+// Logo represents display information for a logo.
+type Logo struct {
+	URL     string `json:"url,omitempty"`
+	AltText string `json:"alt_text,omitempty"`
+}
+
+// CredentialIssuer represents display information about the issuer of some credential(s) for (potentially) multiple
+// locales.
+// Each Display represents display data for a single locale.
+type CredentialIssuer struct {
+	Displays []CredentialIssuerDisplay `json:"display,omitempty"`
+}
+
+// ClaimDisplay represents display data for a specific claim for a single locale.
+type ClaimDisplay struct {
+	Name   string `json:"name,omitempty"`
+	Locale string `json:"locale,omitempty"`
+}
+
+// CredentialIssuerDisplay represents display information for the issuer of some credential(s) for a single locale.
+type CredentialIssuerDisplay struct {
+	Name   string `json:"name,omitempty"`
+	Locale string `json:"locale,omitempty"`
+}

--- a/pkg/openid4ci/models.go
+++ b/pkg/openid4ci/models.go
@@ -6,10 +6,16 @@ SPDX-License-Identifier: Apache-2.0
 
 package openid4ci
 
+import (
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
 // Interaction represents a single OpenID4CI interaction between a wallet and an issuer. The methods defined on this
 // object are used to help guide the calling code through the OpenID4CI flow.
 type Interaction struct {
 	initiationRequest *InitiationRequest
+	issuerMetadata    *issuer.Metadata
+	vcs               []string // base64url encoded
 }
 
 // InitiationRequest represents the Issuance Initiation Request object received from an issuer as defined in
@@ -49,16 +55,6 @@ type tokenResponse struct {
 	RefreshToken    string `json:"refresh_token,omitempty"`
 	CNonce          string `json:"c_nonce,omitempty"`
 	CNonceExpiresIn int    `json:"c_nonce_expires_in,omitempty"`
-}
-
-// issuerMetadata represents metadata about an issuer as obtained from their .well-known OpenID configuration.
-type issuerMetadata struct {
-	Issuer                             string `json:"issuer,omitempty"`
-	AuthorizationEndpoint              string `json:"authorization_endpoint,omitempty"`
-	TokenEndpoint                      string `json:"token_endpoint,omitempty"`
-	PushedAuthorizationRequestEndpoint string `json:"pushed_authorization_request_endpoint,omitempty"`
-	RequirePushedAuthorizationRequests bool   `json:"require_pushed_authorization_requests,omitempty"`
-	CredentialEndpoint                 string `json:"credential_endpoint,omitempty"`
 }
 
 type credentialRequest struct {

--- a/pkg/openid4ci/testdata/credential_university_degree.jsonld
+++ b/pkg/openid4ci/testdata/credential_university_degree.jsonld
@@ -6,9 +6,14 @@
     "https://trustbloc.github.io/context/vc/examples-v1.jsonld"
   ],
   "id": "http://example.edu/credentials/1872",
-  "type": "VerifiableCredential",
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
   "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
+    "given_name": "Alice",
+    "surname": "Bowman",
+    "gpa": "4.0"
   },
   "issuer": {
     "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",

--- a/pkg/openid4ci/testdata/sample_issuer_metadata.json
+++ b/pkg/openid4ci/testdata/sample_issuer_metadata.json
@@ -1,0 +1,73 @@
+{
+  "issuer":"https://server.example.com",
+  "authorization_endpoint":"https://server.example.com/connect/authorize",
+  "token_endpoint":"http://server.example.com/connect/token",
+  "pushed_authorization_request_endpoint":"https://server.example.com/connect/par-authorize",
+  "require_pushed_authorization_requests":false,
+  "credential_endpoint":"http://server.example.com/credential",
+  "credentials_supported": [
+    {
+      "format": "jwt_vc_json",
+      "id": "UniversityDegree_JWT",
+      "types": [
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "cryptographic_binding_methods_supported": [
+        "did"
+      ],
+      "cryptographic_suites_supported": [
+        "ES256K"
+      ],
+      "display": [
+        {
+          "name": "University Credential",
+          "locale": "en-US",
+          "logo": {
+            "url": "https://exampleuniversity.com/public/logo.png",
+            "alternative_text": "a square logo of a university"
+          },
+          "background_color": "#12107c",
+          "text_color": "#FFFFFF"
+        }
+      ],
+      "credentialSubject": {
+        "given_name": {
+          "display": [
+            {
+              "name": "Given Name",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "surname": {
+          "display": [
+            {
+              "name": "Surname",
+              "locale": "en-US"
+            }
+          ]
+        },
+        "gpa": {
+          "display": [
+            {
+              "name": "GPA",
+              "locale": "en-US"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "credential_issuer": {
+    "display": [{
+      "name": "Example University",
+      "locale": "en-US"
+    },
+      {
+        "name": "サンプル大学",
+        "locale": "jp-JA"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
* Added a function that allows a caller to resolve VC display data from an issuer's metadata. This can be called directly or at the end of the OpenID4CI flow using the Interaction object.
* Fixed an issue where one of the memstore unit tests would fail intermittently.
* Updated the linter config.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>