### PR TITLE
feat: Add locale option to ResolveDisplay, request opts constructor

### DIFF
--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
@@ -38,6 +38,11 @@ type CredentialRequestOpts struct {
 	UserPIN string
 }
 
+// NewCredentialRequestOpts returns a new NewCredentialRequestOpts object.
+func NewCredentialRequestOpts(userPIN string) *CredentialRequestOpts {
+	return &CredentialRequestOpts{UserPIN: userPIN}
+}
+
 // ClientConfig contains the various required parameters for an OpenID4CI Interaction.
 type ClientConfig struct {
 	UserDID       string
@@ -126,8 +131,10 @@ func (i *Interaction) RequestCredential(
 // ResolveDisplay is the optional final step that can be called after RequestCredential. It resolves display
 // information for the credentials received in this interaction. The CredentialDisplays in the returned
 // object correspond to the VCs received and are in the same order.
-func (i *Interaction) ResolveDisplay() (*api.JSONObject, error) {
-	resolvedDisplayData, err := i.goAPIInteraction.ResolveDisplay()
+// If preferredLocale is not specified, then the first locale specified by the issuer's metadata will be used during
+// resolution.
+func (i *Interaction) ResolveDisplay(preferredLocale string) (*api.JSONObject, error) {
+	resolvedDisplayData, err := i.goAPIInteraction.ResolveDisplay(preferredLocale)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction_test.go
@@ -121,7 +121,7 @@ func TestInteraction_RequestCredential(t *testing.T) {
 
 		interaction := createInteraction(t, requestURI)
 
-		credentialRequest := &openid4ci.CredentialRequestOpts{}
+		credentialRequest := openid4ci.NewCredentialRequestOpts("")
 
 		result, err := interaction.RequestCredential(credentialRequest)
 		require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestInteraction_RequestCredential(t *testing.T) {
 		interaction, err := openid4ci.NewInteraction(requestURI, config)
 		require.NoError(t, err)
 
-		credentialRequest := &openid4ci.CredentialRequestOpts{}
+		credentialRequest := openid4ci.NewCredentialRequestOpts("")
 
 		result, err := interaction.RequestCredential(credentialRequest)
 		require.EqualError(t, err, "failed to create JWT: failed to create gomobile signer: test failure")

--- a/pkg/openid4ci/openid4ci.go
+++ b/pkg/openid4ci/openid4ci.go
@@ -157,7 +157,9 @@ func (i *Interaction) RequestCredential(credentialRequestOpts *CredentialRequest
 // ResolveDisplay is the optional final step that can be called after RequestCredential. It resolves display
 // information for the credentials received in this interaction. The CredentialDisplays in the returned
 // credentialschema.ResolvedDisplayData object correspond to the VCs received and are in the same order.
-func (i *Interaction) ResolveDisplay() (*credentialschema.ResolvedDisplayData, error) {
+// If preferredLocale is not specified, then the first locale specified by the issuer's metadata will be used during
+// resolution.
+func (i *Interaction) ResolveDisplay(preferredLocale string) (*credentialschema.ResolvedDisplayData, error) {
 	var credentials []*verifiable.Credential
 
 	for _, vc := range i.vcs {
@@ -173,7 +175,8 @@ func (i *Interaction) ResolveDisplay() (*credentialschema.ResolvedDisplayData, e
 
 	return credentialschema.Resolve(
 		credentialschema.WithCredentials(credentials),
-		credentialschema.WithIssuerMetadata(i.issuerMetadata))
+		credentialschema.WithIssuerMetadata(i.issuerMetadata),
+		credentialschema.WithPreferredLocale(preferredLocale))
 }
 
 func (i *Interaction) getTokenResponse(tokenEndpointURL string, params url.Values) (*tokenResponse, error) {

--- a/pkg/openid4ci/openid4ci_test.go
+++ b/pkg/openid4ci/openid4ci_test.go
@@ -488,7 +488,7 @@ func TestInteraction_ResolveDisplay(t *testing.T) {
 		_, err = interaction.RequestCredential(credentialRequest)
 		require.NoError(t, err)
 
-		resolvedDisplayData, err := interaction.ResolveDisplay()
+		resolvedDisplayData, err := interaction.ResolveDisplay("")
 		require.NoError(t, err)
 		require.NotNil(t, resolvedDisplayData)
 	})
@@ -534,7 +534,7 @@ func TestInteraction_ResolveDisplay(t *testing.T) {
 		_, err = interaction.RequestCredential(credentialRequest)
 		require.NoError(t, err)
 
-		resolvedDisplayData, err := interaction.ResolveDisplay()
+		resolvedDisplayData, err := interaction.ResolveDisplay("")
 		require.EqualError(t, err, "unmarshal new credential: invalid character '*' looking for beginning of value")
 		require.Nil(t, resolvedDisplayData)
 	})
@@ -580,7 +580,7 @@ func TestInteraction_ResolveDisplay(t *testing.T) {
 		_, err = interaction.RequestCredential(credentialRequest)
 		require.NoError(t, err)
 
-		resolvedDisplayData, err := interaction.ResolveDisplay()
+		resolvedDisplayData, err := interaction.ResolveDisplay("")
 		require.EqualError(t, err, "unmarshal new credential: unexpected end of JSON input")
 		require.Nil(t, resolvedDisplayData)
 	})

--- a/test/integration/openid4ci_test.go
+++ b/test/integration/openid4ci_test.go
@@ -70,7 +70,7 @@ func TestOpenID4CIFullFlow(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, authorizeResult.UserPINRequired)
 
-	credential, err := interaction.RequestCredential(&openid4ci.CredentialRequestOpts{})
+	credential, err := interaction.RequestCredential(openid4ci.NewCredentialRequestOpts(""))
 
 	require.NoError(t, err)
 	require.NotNil(t, credential)


### PR DESCRIPTION
* Added an option to specify the user's preferred locale to the OpenID4CI ResolveDisplay method on the Interaction object (I had intended for this to be there before, but missed it)
* Added a constructor for the CredentialRequestOpts type. This allows the Java bindings to create a proper constructor for the type.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>