### PR TITLE
feat: Update storage and logic to incorporate validate presentation flow

### DIFF
--- a/demo/app/ios/Podfile.lock
+++ b/demo/app/ios/Podfile.lock
@@ -2,6 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
     - Flutter
+  - integration_test (0.0.1):
+    - Flutter
   - MTBBarcodeScanner (5.0.11)
   - permission_handler_apple (9.0.4):
     - Flutter
@@ -12,6 +14,7 @@ PODS:
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - qr_code_scanner (from `.symlinks/plugins/qr_code_scanner/ios`)
 
@@ -24,6 +27,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_secure_storage:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
   permission_handler_apple:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
   qr_code_scanner:
@@ -32,6 +37,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
+  integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e

--- a/demo/app/lib/demo_method_channel.dart
+++ b/demo/app/lib/demo_method_channel.dart
@@ -29,6 +29,20 @@ class MethodChannelWallet extends WalletPlatform {
     try {
       final credentialResponse =
       await methodChannel.invokeMethod<String>('requestCredential', <String, dynamic>{'otp': userPinEntered});
+      print("request credential");
+      return credentialResponse;
+    } on PlatformException catch (error) {
+      if (error.code == errorCode) {
+        return error.details.toString();
+      }
+    }
+    return null;
+  }
+
+  Future<String?> resolveCredentialDisplay() async {
+    try {
+      final credentialResponse =
+      await methodChannel.invokeMethod<String>('resolveCredentialDisplay');
       return credentialResponse;
     } on PlatformException catch (error) {
       if (error.code == errorCode) {

--- a/demo/app/lib/main.dart
+++ b/demo/app/lib/main.dart
@@ -52,6 +52,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
 
   void _createDid() async {
     var did = await WalletSDKPlugin.createDID();
+    // persist the did
     print("created did:$did");
     setState(() {});
   }

--- a/demo/app/lib/models/credential_data.dart
+++ b/demo/app/lib/models/credential_data.dart
@@ -1,0 +1,22 @@
+
+class CredentialData {
+  final String rawCredential;
+  final String credentialDisplayData;
+
+  CredentialData({ required this.rawCredential, required this.credentialDisplayData});
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['rawCredential'] = rawCredential;
+    data['credentialDisplayData'] = credentialDisplayData;
+    return data;
+  }
+
+  factory CredentialData.fromJson( Map<String, dynamic> json) {
+    return CredentialData(
+      rawCredential: json['rawCredential'],
+      credentialDisplayData: json['credentialDisplayData'],
+    );
+  }
+}
+

--- a/demo/app/lib/models/credential_data_object.dart
+++ b/demo/app/lib/models/credential_data_object.dart
@@ -1,0 +1,8 @@
+import 'package:app/models/credential_data.dart';
+
+class CredentialDataObject {
+  CredentialDataObject(this.key, this.value);
+
+  final String key;
+  final CredentialData value;
+}

--- a/demo/app/lib/services/storage_service.dart
+++ b/demo/app/lib/services/storage_service.dart
@@ -1,3 +1,7 @@
+import 'dart:convert';
+
+import 'package:app/models/credential_data_object.dart';
+import 'package:app/models/credential_data.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:app/models/store_credential_data.dart';
@@ -6,23 +10,37 @@ class StorageService {
   final _secureStorage = const FlutterSecureStorage();
 
   AndroidOptions _getAndroidOptions() => const AndroidOptions(
-    encryptedSharedPreferences: true,
-  );
+        encryptedSharedPreferences: true,
+      );
 
   Future<void> add(StorageItem newItem) async {
     debugPrint("Adding new data having key ${newItem.key}");
+    await _secureStorage.write(key: newItem.key, value: newItem.value, aOptions: _getAndroidOptions());
+  }
+
+  Future<void> addCredential(CredentialDataObject newItem) async {
+    debugPrint("Adding new data having key ${newItem.key}");
     await _secureStorage.write(
-        key: newItem.key, value: newItem.value, aOptions: _getAndroidOptions());
+        key: newItem.key, value: json.encode(newItem.value.toJson()), aOptions: _getAndroidOptions());
+  }
+
+  Future<List<CredentialDataObject>> retrieveCredentials(String username) async {
+    debugPrint("Retrieve all secured data");
+    var allData = await _secureStorage.readAll(aOptions: _getAndroidOptions());
+    List<CredentialDataObject> list = allData.entries
+        .where((e) => e.key.contains(username))
+        .map((e) => CredentialDataObject(e.key, CredentialData.fromJson(jsonDecode(e.value))))
+        .toList();
+    return list;
   }
 
   Future<String?> retrieve(String key) async {
     debugPrint("Retrieve data having key $key");
-    var readData =
-    await _secureStorage.read(key: key, aOptions: _getAndroidOptions());
+    var readData = await _secureStorage.read(key: key, aOptions: _getAndroidOptions());
     return readData;
   }
 
-  Future<void> deleteData(StorageItem item) async {
+  Future<void> deleteData(CredentialDataObject item) async {
     debugPrint("Deleting data having key ${item.key}");
     await _secureStorage.delete(key: item.key, aOptions: _getAndroidOptions());
   }
@@ -30,8 +48,7 @@ class StorageService {
   Future<List<StorageItem>> retrieveAll() async {
     debugPrint("Retrieve all secured data");
     var allData = await _secureStorage.readAll(aOptions: _getAndroidOptions());
-    List<StorageItem> list =
-    allData.entries.map((e) => StorageItem(e.key, e.value)).toList();
+    List<StorageItem> list = allData.entries.map((e) => StorageItem(e.key, e.value)).toList();
     return list;
   }
 
@@ -42,8 +59,7 @@ class StorageService {
 
   Future<bool> containsKeyInSecureData(String key) async {
     debugPrint("Checking data for the key $key");
-    var containsKey = await _secureStorage.containsKey(
-        key: key, aOptions: _getAndroidOptions());
+    var containsKey = await _secureStorage.containsKey(key: key, aOptions: _getAndroidOptions());
     return containsKey;
   }
 }

--- a/demo/app/lib/views/credential_list.dart
+++ b/demo/app/lib/views/credential_list.dart
@@ -3,6 +3,8 @@ import 'package:app/widgets/credential_card.dart';
 import 'package:flutter/material.dart';
 import 'package:app/models/store_credential_data.dart';
 
+import '../models/credential_data_object.dart';
+
 class CredentialList extends StatefulWidget {
   final String title;
   final String? user;
@@ -14,7 +16,8 @@ class CredentialList extends StatefulWidget {
 
 class _CredentialListState extends State<CredentialList> {
   final StorageService _storageService = StorageService();
-  late List<StorageItem> _credentialList;
+ // late List<StorageItem> _credentialList;
+  late List<CredentialDataObject> _credentialList;
   bool _loading = true;
   static String? userIDLoggedIn = '';
   @override
@@ -27,13 +30,11 @@ class _CredentialListState extends State<CredentialList> {
   void initList(String? userIDLoggedIn) async {
     var username = await _storageService.retrieve("username");
     print("username $username");
-      _credentialList = await _storageService.retrieveAll();
-    var credentialResultFound = _credentialList.where((credential) => credential.key.contains(username!));
-    if (credentialResultFound.isEmpty) {
+      _credentialList = await _storageService.retrieveCredentials(username!);
+    if (_credentialList.isEmpty) {
       _loading = true;
       _credentialList.clear();
     }
-    _credentialList = credentialResultFound.toList();
     _loading = false;
     setState(() {});
   }
@@ -55,9 +56,9 @@ class _CredentialListState extends State<CredentialList> {
             itemBuilder: (_, index) {
               return Dismissible(
                 key: Key(_credentialList[index].toString()),
-                child: CredentialCard(item: _credentialList[index]),
+                child: CredentialCard(item: _credentialList[index].value),
                 onDismissed: (direction) async {
-                  await _storageService.deleteData(_credentialList[index]!)
+                  await _storageService.deleteData(_credentialList[index])
                       .then((value) => _credentialList.removeAt(index));
                   initList(widget.user!);
                 },

--- a/demo/app/lib/views/credential_preview.dart
+++ b/demo/app/lib/views/credential_preview.dart
@@ -1,15 +1,18 @@
 import 'dart:convert';
+import 'package:app/models/credential_data.dart';
 import 'package:app/models/credential_preview.dart';
 import 'package:app/views/dashboard.dart';
 import 'package:app/services/storage_service.dart';
 import 'package:app/widgets/add_credential_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
+import '../models/credential_data_object.dart';
 import '../models/store_credential_data.dart';
 
 class CredentialPreview extends StatefulWidget {
-  final String credentialResponse;
-  const CredentialPreview({super.key, required this.credentialResponse});
+  final String rawCredential;
+  final String credentialDisplay;
+  const CredentialPreview({super.key, required this.rawCredential, required this.credentialDisplay});
 
   @override
   State<CredentialPreview> createState() => CredentialPreviewState();
@@ -31,7 +34,7 @@ class CredentialPreviewState extends State<CredentialPreview> {
 
   Future<List<CredentialPreviewData>> getData() async {
     List<CredentialPreviewData> list;
-      var data = json.decode(widget.credentialResponse);
+      var data = json.decode(widget.credentialDisplay);
       var credentialClaimsData = data['credential_displays'][0]['claims'] as List;
       list = credentialClaimsData.map<CredentialPreviewData>((json) => CredentialPreviewData.fromJson(json)).toList();
     return list;
@@ -66,7 +69,7 @@ class CredentialPreviewState extends State<CredentialPreview> {
   }
   @override
   Widget build(BuildContext context) {
-    Map<String, dynamic> issuer = jsonDecode(widget.credentialResponse);
+    Map<String, dynamic> issuer = jsonDecode(widget.credentialDisplay);
     final issuerDisplayData = issuer['issuer_display']['name'];
     return Scaffold(
       appBar: AppBar(
@@ -124,8 +127,8 @@ class CredentialPreviewState extends State<CredentialPreview> {
                     final StorageItem? newItem = await showDialog<StorageItem>(
                         context: context, builder: (_) => AddDataDialog());
                     if (newItem != null) {
-                      _storageService.add(StorageItem("$userLoggedIn-credential-${uuid.v1()}", widget.credentialResponse));
-                      _navigateToDashboard(userLoggedIn);
+                       _storageService.addCredential(CredentialDataObject("$userLoggedIn-${uuid.v1()}",CredentialData(rawCredential: widget.rawCredential, credentialDisplayData: widget.credentialDisplay)));
+                       _navigateToDashboard(userLoggedIn);
                     }
                   },
                   child: const Text("Save Credential"),

--- a/demo/app/lib/views/otp.dart
+++ b/demo/app/lib/views/otp.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:app/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -63,9 +65,10 @@ class _OTPPage extends State<OTP> {
                       _fieldSix.text;
                 });
                   var requestCredentialResp =  await WalletSDKPlugin.requestCredential(_otp!);
+                  var resolvedCredentialDisplay =  await WalletSDKPlugin.resolveCredentialDisplay();
                   // Making sure request credential response doesn't contain error
-                  if (!requestCredentialResp!.contains("generic-error")) {
-                    _navigateToCredPreviewScreen(requestCredentialResp);
+                  if (!resolvedCredentialDisplay!.contains("generic-error")) {
+                    _navigateToCredPreviewScreen(requestCredentialResp!, resolvedCredentialDisplay);
                   } else {
                     setState(() {
                       _requestCredentialErrorMsg = requestCredentialResp.toString();
@@ -90,8 +93,8 @@ class _OTPPage extends State<OTP> {
       ),
     );
   }
-  _navigateToCredPreviewScreen(String credentialResp) async {
-    Navigator.push(context, MaterialPageRoute(builder: (context) => CredentialPreview(credentialResponse: credentialResp)));
+  _navigateToCredPreviewScreen(String credentialResp, String credentialResolveDisplay) async {
+    Navigator.push(context, MaterialPageRoute(builder: (context) => CredentialPreview(rawCredential: credentialResp,credentialDisplay: credentialResolveDisplay)));
   }
 
   _clearOTPInput(){

--- a/demo/app/lib/widgets/credential_card.dart
+++ b/demo/app/lib/widgets/credential_card.dart
@@ -1,12 +1,13 @@
 import 'dart:convert';
 
+import 'package:app/models/credential_data.dart';
 import 'package:flutter/material.dart';
 import 'package:app/models/store_credential_data.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:app/models/credential_preview.dart';
 
 class CredentialCard extends StatefulWidget {
-  StorageItem item;
+  CredentialData item;
 
   CredentialCard({required this.item, Key? key}) : super(key: key);
 
@@ -19,7 +20,7 @@ class _CredentialCardState extends State<CredentialCard> {
 
   Widget getCredentialDetails() {
     List<CredentialPreviewData> list;
-    var data = json.decode(widget.item.value);
+    var data = json.decode(widget.item.credentialDisplayData);
     var credentialClaimsData = data['credential_displays'][0]['claims'] as List;
     list = credentialClaimsData.map<CredentialPreviewData>((json) => CredentialPreviewData.fromJson(json)).toList();
     return listViewWidget(list);
@@ -55,7 +56,7 @@ class _CredentialCardState extends State<CredentialCard> {
 
   @override
   Widget build(BuildContext context) {
-    Map<String, dynamic> issuer = jsonDecode(widget.item.value);
+    Map<String, dynamic> issuer = jsonDecode(widget.item.credentialDisplayData);
     final credentialDisplayName = issuer['credential_displays'][0]['overview']['name'];
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),


### PR DESCRIPTION
This pr stores the credential data in the secure storage in the following format 
`{"rawCredential": "data...", 
    "credentialDisplay": "data"}`

This format helps us to retrieve the raw credential to send to presentationAuthorize flow.  Issuance flow works as before. Tested

Signed-off-by: Talwinder kaur <talwinder.kaur@avast.com>