### PR TITLE
fix: update android resolve display

### DIFF
--- a/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
@@ -75,6 +75,16 @@ class MainActivity : FlutterActivity() {
                             }
                         }
 
+                        "resolveCredentialDisplay" -> {
+                            try {
+                                val credentialDisplay = resolveCredentialDisplay(call)
+                                result.success(credentialDisplay)
+
+                            } catch (e: Exception) {
+                                result.error("Exception", "Error while resolving credential display", e)
+                            }
+                        }
+
                         "processAuthorizationRequest" -> {
                             try {
                                 val creds = processAuthorizationRequest(call);
@@ -177,7 +187,17 @@ class MainActivity : FlutterActivity() {
         return resp
     }
 
-    private fun createDID(): String {
+    public fun resolveCredentialDisplay(call: MethodCall) : String?{
+        val openID4CI = this.openID4CI
+            ?: throw java.lang.Exception("openID4CI not initiated. Call authorize before this.")
+
+        val resp = openID4CI.resolveCredentialDisplay() ?: return null
+
+        return resp
+    }
+
+
+       private fun createDID(): String {
         val kms = this.kms ?: throw java.lang.Exception("SDK is not initialized, call initSDK()")
 
         val creatorDID = Creator(kms as KeyWriter)

--- a/demo/app/android/app/src/main/kotlin/walletsdk/openid4ci/OpenID4CI.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/openid4ci/OpenID4CI.kt
@@ -42,4 +42,9 @@ class OpenID4CI constructor(
 
         return null
     }
+
+    fun resolveCredentialDisplay(): String? {
+        val resolvedDisplayData = newInteraction.resolveDisplay("")
+        return String(resolvedDisplayData.data)
+    }
 }

--- a/demo/app/android/app/src/main/kotlin/walletsdk/openid4vp/OpenID4VP.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/openid4vp/OpenID4VP.kt
@@ -42,8 +42,8 @@ class OpenID4VP constructor(
         this.verifiablePresentation = verifiablePresentation
         initiatedInteraction = interaction
 
-        return List<String>(matchedCreds.length().toInt(),
-                { i: Int -> matchedCreds.atIndex(i.toLong()).content })
+        return List<String>(matchedCreds.length().toInt()
+        ) { i: Int -> matchedCreds.atIndex(i.toLong()).content }
     }
 
     fun presentCredential(didVerificationMethod: VerificationMethod) {

--- a/demo/app/lib/main.dart
+++ b/demo/app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'demo_method_channel.dart';
 import 'models/store_credential_data.dart';
@@ -53,7 +55,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
   void _createDid() async {
     var did = await WalletSDKPlugin.createDID();
     // persist the did
-    print("created did:$did");
+    log("created did:$did");
     setState(() {});
   }
 


### PR DESCRIPTION
This pr fixes the below: 
Resolve display call was missing in the android 
Updating the ios plugin to accomodate latest ios bindings changes. 

Vp flow is giving `[VERBOSE-2:dart_vm_initializer.cc(41)] Unhandled Exception: PlatformException(NATIVE_ERR, error while process authorization request, Error Domain=go Code=1 "credentials do not satisfy requirements" UserInfo={NSLocalizedDescription=credentials do not satisfy requirements}, null)`. in both android n ios its in progress 

Signed-off-by: Talwinder kaur <talwinder.kaur@avast.com>