### PR TITLE
fix: [OpenID4VP]  add aud/nbf/iat/jti values to id_token and vp_token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ go 1.19
 
 require (
 	github.com/google/tink/go v1.7.0
+	github.com/google/uuid v1.3.0
 	github.com/hyperledger/aries-framework-go v0.1.9-0.20221219221222-fdd5069d178e
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221209153644-5a3273a805c1
 	github.com/piprate/json-gold v0.4.2
@@ -26,7 +27,6 @@ require (
 	github.com/go-jose/go-jose/v3 v3.0.1-0.20221117193127-916db76e8214 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v1.0.0-rc3.0.20221104150937-07bfbe450122 // indirect
 	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220610133818-119077b0ec85 // indirect
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20221025204933-b807371b6f1e // indirect

--- a/pkg/openid4vp/tokens.go
+++ b/pkg/openid4vp/tokens.go
@@ -20,6 +20,10 @@ type idTokenClaims struct {
 	Exp     int64          `json:"exp"`
 	Iss     string         `json:"iss"`
 	Sub     string         `json:"sub"`
+	Aud     string         `json:"aud"`
+	Nbf     int64          `json:"nbf"`
+	Iat     int64          `json:"iat"`
+	Jti     string         `json:"jti"`
 }
 
 type vpTokenClaims struct {
@@ -27,4 +31,8 @@ type vpTokenClaims struct {
 	Nonce string                   `json:"nonce"`
 	Exp   int64                    `json:"exp"`
 	Iss   string                   `json:"iss"`
+	Aud   string                   `json:"aud"`
+	Nbf   int64                    `json:"nbf"`
+	Iat   int64                    `json:"iat"`
+	Jti   string                   `json:"jti"`
 }


### PR DESCRIPTION
- Add workaround for PEx to send pathNested
- Add missing fields to id and vp token

Signed-off-by: Rolson Quadras <rolson.quadras@avast.com>