### PR TITLE
fix: Skipped mobile bindings

### DIFF
--- a/cmd/wallet-sdk-gomobile/api/api.go
+++ b/cmd/wallet-sdk-gomobile/api/api.go
@@ -7,10 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 // Package api defines gomobile-compatible wallet-sdk interfaces.
 package api
 
-import (
-	"github.com/hyperledger/aries-framework-go/pkg/kms"
-)
-
 // JSONObject contains a single JSON object (not an array).
 // It's a simple wrapper around the actual JSON string. Its purpose is to help the
 // caller using the mobile bindings to understand what type of data to expect or pass in.
@@ -49,7 +45,7 @@ type KeyReader interface {
 type CreateDIDOpts struct {
 	KeyID            string
 	VerificationType string
-	KeyType          kms.KeyType
+	KeyType          string
 }
 
 // DIDCreator defines the method required for a type to create DID documents.

--- a/cmd/wallet-sdk-gomobile/credential/inquirer.go
+++ b/cmd/wallet-sdk-gomobile/credential/inquirer.go
@@ -58,8 +58,8 @@ type VerifiablePresentation struct {
 	wrapped *verifiable.Presentation
 }
 
-// WrapVerifiablePresentation wraps go implementation of verifiable presentation into gomobile compatible struct.
-func WrapVerifiablePresentation(vp *verifiable.Presentation) *VerifiablePresentation {
+// wrapVerifiablePresentation wraps go implementation of verifiable presentation into gomobile compatible struct.
+func wrapVerifiablePresentation(vp *verifiable.Presentation) *VerifiablePresentation {
 	return &VerifiablePresentation{wrapped: vp}
 }
 
@@ -138,7 +138,7 @@ func (c *Inquirer) Query(query []byte, contents *CredentialsOpt) (*VerifiablePre
 		return nil, fmt.Errorf("query is failed: %w", err)
 	}
 
-	return WrapVerifiablePresentation(presentation), err
+	return wrapVerifiablePresentation(presentation), err
 }
 
 func (c *Inquirer) parseVC(rawCreds *api.VerifiableCredentialsArray) ([]*verifiable.Credential, error) {

--- a/cmd/wallet-sdk-gomobile/did/creator.go
+++ b/cmd/wallet-sdk-gomobile/did/creator.go
@@ -10,6 +10,8 @@ package did
 import (
 	"errors"
 
+	arieskms "github.com/hyperledger/aries-framework-go/pkg/kms"
+
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	goapi "github.com/trustbloc/wallet-sdk/pkg/api"
 	goapicreator "github.com/trustbloc/wallet-sdk/pkg/did/creator"
@@ -100,6 +102,6 @@ func convertToGoAPIOpts(createDIDOpts *api.CreateDIDOpts) *goapi.CreateDIDOpts {
 	return &goapi.CreateDIDOpts{
 		KeyID:            createDIDOpts.KeyID,
 		VerificationType: createDIDOpts.VerificationType,
-		KeyType:          createDIDOpts.KeyType,
+		KeyType:          arieskms.KeyType(createDIDOpts.KeyType),
 	}
 }

--- a/cmd/wallet-sdk-gomobile/go.mod
+++ b/cmd/wallet-sdk-gomobile/go.mod
@@ -63,7 +63,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
-	golang.org/x/sys v0.3.0 // indirect
+	golang.org/x/sys v0.4.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cmd/wallet-sdk-gomobile/go.sum
+++ b/cmd/wallet-sdk-gomobile/go.sum
@@ -175,8 +175,8 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
-golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -70,7 +70,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.1.0 // indirect
-	golang.org/x/sys v0.3.0 // indirect
+	golang.org/x/sys v0.4.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/test/integration/go.sum
+++ b/test/integration/go.sum
@@ -196,8 +196,8 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
-golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
* Fixed an issue where the CreateDIDOpts KeyType option was not accessible in the mobile bindings due to using an incompatible type
* Made the WrapVerifiablePresentation function private as it's not compatible with gomobile (and didn't need to be exported anyway). It was causing a "skipped function" warning in the bindings.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>