### PR TITLE
fix: error in generate_package_list.sh on Linux

### DIFF
--- a/cmd/wallet-sdk-gomobile/scripts/build_android_bindings.sh
+++ b/cmd/wallet-sdk-gomobile/scripts/build_android_bindings.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright Avast Software. All Rights Reserved.
 #

--- a/cmd/wallet-sdk-gomobile/scripts/build_ios_bindings.sh
+++ b/cmd/wallet-sdk-gomobile/scripts/build_ios_bindings.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright Avast Software. All Rights Reserved.
 #

--- a/cmd/wallet-sdk-gomobile/scripts/generate_package_list.sh
+++ b/cmd/wallet-sdk-gomobile/scripts/generate_package_list.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright Avast Software. All Rights Reserved.
 #
@@ -8,9 +9,14 @@
 
 all_packages=$(go list ./...)
 
+# Depending on the environment, all_packages may use newlines to separate packages instead of spaces.
+# The line below converts the newlines to spaces for compatibility with the gomobile command.
+# If all_packages already uses spaces, then this command won't make any changes.
 all_packages_space_separated="${all_packages//$'\n'/ }"
 
-# Only used internally. This package contains exported functions that are not gomobile compatible, and we don't want or need this to be exposed to the user of the SDK
+# The wrapper package is only used internally. Since this package contains exported functions that are not gomobile
+# compatible, and we don't want or need this to be exposed to the user of the SDK, we exclude it from the gomobile
+# bindings.
 package_to_remove="github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 
 packages_for_bindings="${all_packages_space_separated//$package_to_remove/}"


### PR DESCRIPTION
* Fixed the "Bad substitution" error that happens on Linux by adding a bash shebang to the generate_package_list.sh file
* For consistency with other scripts (though not required for the fix above), also added a bash shebang to the build_android_bindings.sh and build_ios_bindings.sh files as well
* Added a comment explaining the reason for the newline -> space substitution operation in the generate_package_list.sh file

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>