### PR TITLE
ci(sdk,app): make scope mandatory for conventional commit message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v4
+        with:
+          requireScope: true
+          scopes: |
+            sdk
+            app
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Make scope mandatory
- Add sdk and app as the available scope

Signed-off-by: Rolson Quadras <rolson.quadras@avast.com>