### PR TITLE
fix(sdk): NewSigner constructor being skipped in mobile bindings

### DIFF
--- a/cmd/wallet-sdk-gomobile/credential/signer.go
+++ b/cmd/wallet-sdk-gomobile/credential/signer.go
@@ -27,16 +27,17 @@ func NewSigner(
 	credReader api.CredentialReader,
 	didResolver api.DIDResolver,
 	crypto api.Crypto,
-	ldLoader ld.DocumentLoader,
+	ldLoader api.LDDocumentLoader,
 ) (*Signer, error) {
-	readerWrapper := &wrapper.CredentialReaderWrapper{CredentialReader: credReader, DocumentLoader: ldLoader}
+	ldLoaderWrapper := &wrapper.DocumentLoaderWrapper{DocumentLoader: ldLoader}
+	readerWrapper := &wrapper.CredentialReaderWrapper{CredentialReader: credReader, DocumentLoader: ldLoaderWrapper}
 	resolverWrapper := &wrapper.VDRResolverWrapper{DIDResolver: didResolver}
 
 	sdkSigner := credentialsigner.New(readerWrapper, resolverWrapper, crypto)
 
 	return &Signer{
 		signer:   sdkSigner,
-		ldLoader: ldLoader,
+		ldLoader: ldLoaderWrapper,
 	}, nil
 }
 

--- a/cmd/wallet-sdk-gomobile/credential/signer_test.go
+++ b/cmd/wallet-sdk-gomobile/credential/signer_test.go
@@ -55,7 +55,7 @@ func TestSigner_Issue(t *testing.T) {
 				&mockReader{},
 				&mockResolver{ResolveVal: mockDocResolution(t)},
 				&mockCrypto{SignVal: []byte("foo")},
-				testutil.DocumentLoader(t),
+				&documentLoaderReverseWrapper{DocumentLoader: testutil.DocumentLoader(t)},
 			)
 			require.NoError(t, err)
 
@@ -69,7 +69,7 @@ func TestSigner_Issue(t *testing.T) {
 				&mockReader{GetVal: mockCredBytes},
 				&mockResolver{ResolveVal: mockDocResolution(t)},
 				&mockCrypto{SignVal: []byte("foo")},
-				testutil.DocumentLoader(t),
+				&documentLoaderReverseWrapper{DocumentLoader: testutil.DocumentLoader(t)},
 			)
 			require.NoError(t, err)
 
@@ -85,7 +85,7 @@ func TestSigner_Issue(t *testing.T) {
 				&mockReader{},
 				&mockResolver{ResolveVal: mockDocResolution(t)},
 				&mockCrypto{SignVal: []byte("foo")},
-				testutil.DocumentLoader(t),
+				&documentLoaderReverseWrapper{DocumentLoader: testutil.DocumentLoader(t)},
 			)
 			require.NoError(t, err)
 
@@ -99,7 +99,7 @@ func TestSigner_Issue(t *testing.T) {
 				&mockReader{},
 				&mockResolver{ResolveVal: mockDocResolution(t)},
 				&mockCrypto{SignErr: expectErr},
-				testutil.DocumentLoader(t),
+				&documentLoaderReverseWrapper{DocumentLoader: testutil.DocumentLoader(t)},
 			)
 			require.NoError(t, err)
 


### PR DESCRIPTION
Signed-off-by: Derek Trider <Derek.Trider@securekey.com>