### PR TITLE
feat(sdk,app): Smaller mobile bindings

### DIFF
--- a/cmd/wallet-sdk-gomobile/scripts/build_android_bindings.sh
+++ b/cmd/wallet-sdk-gomobile/scripts/build_android_bindings.sh
@@ -11,4 +11,4 @@ packages_for_bindings=$(. scripts/generate_package_list.sh)
 
 android_java_pkg="dev.trustbloc.wallet.sdk"
 
-gomobile bind -androidapi 22 -o bindings/android/walletsdk.aar -javapkg=${android_java_pkg-pkg} -target=android ${packages_for_bindings}
+gomobile bind -ldflags '-w -s' -androidapi 22 -o bindings/android/walletsdk.aar -javapkg=${android_java_pkg-pkg} -target=android ${packages_for_bindings}

--- a/cmd/wallet-sdk-gomobile/scripts/build_ios_bindings.sh
+++ b/cmd/wallet-sdk-gomobile/scripts/build_ios_bindings.sh
@@ -9,4 +9,4 @@
 
 packages_for_bindings=$(. scripts/generate_package_list.sh)
 
-gomobile bind -target=ios -o bindings/ios/walletsdk.xcframework ${packages_for_bindings}
+gomobile bind -ldflags '-w -s' -target=ios -o bindings/ios/walletsdk.xcframework ${packages_for_bindings}


### PR DESCRIPTION
* Decreased the size of the Android bindings by ~44% (45.3 MB -> 25.5 MB) and decreased the size of the iOS bindings by ~47% (37.5 MB -> 20.1 MB) by adding linker flags that remove unneeded debug information from the generated binaries.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>