### PR TITLE
fix(sdk): Runtime error when injecting local KMS store from mobile

### DIFF
--- a/cmd/wallet-sdk-gomobile/did/creator_test.go
+++ b/cmd/wallet-sdk-gomobile/did/creator_test.go
@@ -29,8 +29,7 @@ func (m *mockKeyHandleReader) ExportPubKey(string) ([]byte, error) {
 
 func TestNewCreatorWithKeyWriter(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		localKMS, err := localkms.NewKMS(nil)
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		didCreator, err := did.NewCreatorWithKeyWriter(localKMS)
 		require.NoError(t, err)
@@ -45,8 +44,7 @@ func TestNewCreatorWithKeyWriter(t *testing.T) {
 
 func TestNewCreatorWithKeyReader(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		localKMS, err := localkms.NewKMS(nil)
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		didCreator, err := did.NewCreatorWithKeyReader(localKMS)
 		require.NoError(t, err)
@@ -61,8 +59,7 @@ func TestNewCreatorWithKeyReader(t *testing.T) {
 
 func TestCreator_Create(t *testing.T) {
 	t.Run("Using KeyWriter (automatic key generation) - success", func(t *testing.T) {
-		localKMS, err := localkms.NewKMS(nil)
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		creator, err := did.NewCreatorWithKeyWriter(localKMS)
 		require.NoError(t, err)
@@ -110,4 +107,15 @@ func TestCreator_Create(t *testing.T) {
 			require.Empty(t, didDocResolution)
 		})
 	})
+}
+
+func createTestKMS(t *testing.T) *localkms.KMS {
+	t.Helper()
+
+	kmsStore := localkms.NewMemKMSStore()
+
+	localKMS, err := localkms.NewKMS(kmsStore)
+	require.NoError(t, err)
+
+	return localKMS
 }

--- a/cmd/wallet-sdk-gomobile/docs/usage.md
+++ b/cmd/wallet-sdk-gomobile/docs/usage.md
@@ -64,12 +64,13 @@ retrievedVCs = db.getAll()
 db.remove("VC_ID")
 ```
 
-## KMS
-This package contains a KMS implementation that uses Google's Tink crypto library.
+## Local KMS
+This package contains a local KMS implementation that uses Google's Tink crypto library.
 Private keys may intermittently reside in local memory with this implementation so
 keep this consideration in mind when deciding whether to use this or not.
-The key store can be injected in by the caller. If the store argument in the constructor is left null/nil,
-then an in-memory key store will be used.
+The caller must inject a key store for the KMS to use. This package includes an in-memory key store implementation
+that can be used, but you will likely want to inject in your own implementation at some point so your keys are
+persisted.
 
 ### Examples
 
@@ -77,8 +78,10 @@ then an in-memory key store will be used.
 
 ```kotlin
 import dev.trustbloc.wallet.sdk.localkms.Localkms
+import dev.trustbloc.wallet.sdk.localkms.MemKMSStore
 
-val kms = Localkms.newKMS(null) // The null store argument causes it to use in-memory storage
+val memKMSStore = MemKMSStore.MemKMSStore()
+val kms = Localkms.newKMS(memKMSStore)
 
 val keyHandle = kms.create(localkms.KeyTypeED25519)
 ```
@@ -88,7 +91,8 @@ val keyHandle = kms.create(localkms.KeyTypeED25519)
 ```swift
 import Walletsdk
 
-let kms = LocalkmsNewKMS(nil, nil) // The nil store argument causes it to use in-memory storage
+let memKMSStore = LocalkmsNewMemKMSStore()
+let kms = LocalkmsNewKMS(memKMSStore, nil)
 
 let keyHandle = kms.create(LocalkmsKeyTypeED25519)
 ```
@@ -112,8 +116,10 @@ The Keys used for DID documents are created for you automatically by the key wri
 import dev.trustbloc.wallet.sdk.api.CreateDIDOpts
 import dev.trustbloc.wallet.sdk.did.Creator
 import dev.trustbloc.wallet.sdk.localkms.Localkms
+import dev.trustbloc.wallet.sdk.localkms.MemKMSStore
 
-val kms = Localkms.newKMS(null) // The null store argument causes it to use in-memory storage
+val memKMSStore = MemKMSStore.MemKMSStore()
+val kms = Localkms.newKMS(memKMSStore)
 val didCreator = Creator(kms as KeyWriter)
 val didDocResolution = didCreator.create("key", CreateDIDOpts()) // Create a did:key doc
 ```
@@ -123,7 +129,8 @@ val didDocResolution = didCreator.create("key", CreateDIDOpts()) // Create a did
 ```swift
 import Walletsdk
 
-let kms = LocalkmsNewKMS(nil, nil) // The nil store argument causes it to use in-memory storage
+let memKMSStore = LocalkmsNewMemKMSStore()
+let kms = LocalkmsNewKMS(memKMSStore, nil)
 let didCreator = DidNewCreatorWithKeyWriter(kms, nil)
 let didDocResolution = didCreator.create("key", ApiCreateDIDOpts()) // Create a did:key doc
 ```
@@ -142,8 +149,10 @@ import dev.trustbloc.wallet.sdk.api.CreateDIDOpts
 import dev.trustbloc.wallet.sdk.did.Creator
 import dev.trustbloc.wallet.sdk.did.Did.Ed25519VerificationKey2018
 import dev.trustbloc.wallet.sdk.localkms.Localkms
+import dev.trustbloc.wallet.sdk.localkms.MemKMSStore
 
-val kms = Localkms.newKMS(null) // The null store argument causes it to use in-memory storage
+val memKMSStore = MemKMSStore.MemKMSStore()
+val kms = Localkms.newKMS(memKMSStore)
 
 val keyHandle = kms.create(localkms.KeyTypeED25519)
 
@@ -161,7 +170,8 @@ val didDocResolution = didCreator.create("key", createDIDOpts) // Create a did:k
 ```swift
 import Walletsdk
 
-let kms = LocalkmsNewKMS(nil) // The nil store argument causes it to use in-memory storage
+let memKMSStore = LocalkmsNewMemKMSStore()
+let kms = LocalkmsNewKMS(memKMSStore)
 
 let keyHandle = kms.create(LocalkmsKeyTypeED25519)
 
@@ -209,8 +219,10 @@ import dev.trustbloc.wallet.sdk.api.CreateDIDOpts
 import dev.trustbloc.wallet.sdk.did.Creator
 import dev.trustbloc.wallet.sdk.did.Did.Ed25519VerificationKey2018
 import dev.trustbloc.wallet.sdk.localkms.Localkms
+import dev.trustbloc.wallet.sdk.localkms.MemKMSStore
 
-val kms = Localkms.newKMS(null) // The null store argument causes it to use in-memory storage
+val memKMSStore = MemKMSStore.MemKMSStore()
+val kms = Localkms.newKMS(memKMSStore)
 
 val keyHandle = kms.create(localkms.KeyTypeED25519)
 
@@ -228,7 +240,8 @@ val didDocResolution = didCreator.create("key", createDIDOpts) // Create a did:k
 ```swift
 import Walletsdk
 
-let kms = LocalkmsNewKMS(nil, nil) // The nil store argument causes it to use in-memory storage
+let memKMSStore = LocalkmsNewMemKMSStore()
+let kms = LocalkmsNewKMS(memKMSStore, nil)
 
 let keyHandle = kms.create(LocalkmsKeyTypeED25519)
 
@@ -319,6 +332,7 @@ They use in-memory key storage and the Tink crypto library.
 
 ```kotlin
 import dev.trustbloc.wallet.sdk.localkms.Localkms
+import dev.trustbloc.wallet.sdk.localkms.MemKMSStore
 import dev.trustbloc.wallet.sdk.localkms.SignerCreator
 import dev.trustbloc.wallet.sdk.did.Resolver
 import dev.trustbloc.wallet.sdk.did.Creator
@@ -328,7 +342,8 @@ import dev.trustbloc.wallet.sdk.openid4ci.CredentialRequestOpts
 import dev.trustbloc.wallet.sdk.openid4ci.mem
 
 // Setup
-val kms = Localkms.newKMS(null)// The null store argument causes it to use in-memory storage. Will use the Tink crypto library.
+val memKMSStore = MemKMSStore.MemKMSStore()
+val kms = Localkms.newKMS(memKMSStore)
 val signerCreator = Localkms.createSignerCreator(kms) // Will use the Tink crypto library
 val didResolver = Resolver("")
 val didCreator = Creator(kms as KeyWriter)
@@ -352,7 +367,8 @@ val displayData = interaction.resolveDisplay("en-US") // Optional (but useful)
 import Walletsdk
 
 // Setup
-let kms = DidNewResolver("", nil) // The nil store argument causes it to use in-memory storage. Will use the Tink crypto library.
+let memKMSStore = LocalkmsNewMemKMSStore()
+let kms = LocalkmsNewKMS(memKMSStore, nil)
 let signerCreator = LocalkmsCreateSignerCreator(kms, nil) // Will use the Tink crypto library
 let didResolver = DidNewResolver("", nil)
 let didCreator = DidNewCreatorWithKeyWriter(kms, nil)
@@ -398,6 +414,7 @@ They use in-memory key storage and the Tink crypto library.
 
 ```kotlin
 import dev.trustbloc.wallet.sdk.localkms.Localkms
+import dev.trustbloc.wallet.sdk.localkms.MemKMSStore
 import dev.trustbloc.wallet.sdk.localkms.SignerCreator
 import dev.trustbloc.wallet.sdk.did.Resolver
 import dev.trustbloc.wallet.sdk.did.Creator
@@ -409,7 +426,8 @@ import dev.trustbloc.wallet.sdk.credential
 import dev.trustbloc.wallet.sdk.openid4ci.mem
 
 // Setup
-val kms = Localkms.newKMS(null)// The null store argument causes it to use in-memory storage. Will use the Tink crypto library.
+val memKMSStore = MemKMSStore.MemKMSStore()
+val kms = Localkms.newKMS(memKMSStore)
 val signerCreator = Localkms.createSignerCreator(kms) // Will use the Tink crypto library
 val didResolver = Resolver("")
 val didCreator = Creator(kms as KeyWriter)
@@ -435,7 +453,8 @@ interaction.presentCredential(verifiablePres, keyID)
 import Walletsdk
 
 // Setup
-let kms = DidNewResolver("", nil) // The nil store argument causes it to use in-memory storage. Will use the Tink crypto library.
+let memKMSStore = LocalkmsNewMemKMSStore()
+let kms = LocalkmsNewKMS(memKMSStore, nil)
 let signerCreator = LocalkmsCreateSignerCreator(kms, nil) // Will use the Tink crypto library
 let didResolver = DidNewResolver("", nil)
 let didCreator = DidNewCreatorWithKeyWriter(kms, nil)

--- a/cmd/wallet-sdk-gomobile/go.mod
+++ b/cmd/wallet-sdk-gomobile/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/google/uuid v1.3.0
 	github.com/hyperledger/aries-framework-go v0.1.9-0.20230123141502-39b647b282e2
-	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220610133818-119077b0ec85
 	github.com/piprate/json-gold v0.4.2
 	github.com/stretchr/testify v1.8.1
 	github.com/trustbloc/wallet-sdk v0.0.0-00010101000000-000000000000
@@ -31,6 +30,7 @@ require (
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/jwk v0.0.0-20221209153644-5a3273a805c1 // indirect
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/longform v0.0.0-20221209153644-5a3273a805c1 // indirect
 	github.com/hyperledger/aries-framework-go-ext/component/vdr/sidetree v1.0.0-rc3.0.20221104150937-07bfbe450122 // indirect
+	github.com/hyperledger/aries-framework-go/component/storageutil v0.0.0-20220610133818-119077b0ec85 // indirect
 	github.com/hyperledger/aries-framework-go/spi v0.0.0-20221025204933-b807371b6f1e // indirect
 	github.com/hyperledger/ursa-wrapper-go v0.3.1 // indirect
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a // indirect

--- a/cmd/wallet-sdk-gomobile/localkms/localkms_test.go
+++ b/cmd/wallet-sdk-gomobile/localkms/localkms_test.go
@@ -7,22 +7,21 @@ SPDX-License-Identifier: Apache-2.0
 package localkms_test
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/btcsuite/btcutil/base58"
-	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk/jwksupport"
-	arieskms "github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/stretchr/testify/require"
 
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/localkms"
 )
 
+func TestNewKMS(t *testing.T) {
+	kms, err := localkms.NewKMS(nil)
+	require.EqualError(t, err, "kmsStore cannot be nil")
+	require.Nil(t, kms)
+}
+
 func TestLocalKMS_Create(t *testing.T) {
-	localKMS, err := localkms.NewKMS(nil)
-	require.NoError(t, err)
+	localKMS := createTestKMS(t)
 
 	keyHandle, err := localKMS.Create(localkms.KeyTypeED25519)
 	require.NoError(t, err)
@@ -31,8 +30,7 @@ func TestLocalKMS_Create(t *testing.T) {
 }
 
 func TestLocalKMS_ExportPubKey(t *testing.T) {
-	localKMS, err := localkms.NewKMS(nil)
-	require.NoError(t, err)
+	localKMS := createTestKMS(t)
 
 	keyHandle, err := localKMS.Create(localkms.KeyTypeED25519)
 	require.NoError(t, err)
@@ -44,110 +42,19 @@ func TestLocalKMS_ExportPubKey(t *testing.T) {
 }
 
 func TestLocalKMS_GetCrypto(t *testing.T) {
-	localKMS, err := localkms.NewKMS(nil)
-	require.NoError(t, err)
+	localKMS := createTestKMS(t)
 
 	crypto := localKMS.GetCrypto()
 	require.NotNil(t, crypto)
 }
 
-func TestGetDefaultSignerCreator(t *testing.T) {
-	newSignerCreator(t)
-}
-
-func TestSignerCreator_Create(t *testing.T) {
-	t.Run("Unmarshal failure", func(t *testing.T) {
-		signerCreator := newSignerCreator(t)
-
-		signer, err := signerCreator.Create(&api.JSONObject{})
-		require.EqualError(t, err, "failed to unmarshal verification method JSON into a did.VerificationMethod")
-		require.Nil(t, signer)
-	})
-	t.Run("fail to parse verification method JWK", func(t *testing.T) {
-		signerCreator := newSignerCreator(t)
-
-		signer, err := signerCreator.Create(&api.JSONObject{
-			Data: []byte(`{
-				"id": "foo",
-				"type": "JsonWebKey2020",
-				"publicKeyJwk": {}
-			}`),
-		})
-		require.EqualError(t, err, "failed to unmarshal verification method JSON into a did.VerificationMethod")
-		require.Nil(t, signer)
-	})
-	t.Run("Failed to create Aries signer", func(t *testing.T) {
-		signerCreator := newSignerCreator(t)
-
-		signer, err := signerCreator.Create(&api.JSONObject{Data: []byte("{}")})
-		require.EqualError(t, err, "failed to create Aries signer: parsing verification method: vm.Type '' not supported")
-		require.Nil(t, signer)
-	})
-	t.Run("success - verification method with raw key bytes", func(t *testing.T) {
-		kmsStore, err := arieskms.NewAriesProviderWrapper(mem.NewProvider())
-		require.NoError(t, err)
-
-		keyManager, err := localkms.NewKMS(kmsStore)
-		require.NoError(t, err)
-
-		key, err := keyManager.Create(localkms.KeyTypeED25519)
-		require.NoError(t, err)
-
-		signerCreator, err := localkms.NewSignerCreator(keyManager)
-		require.NoError(t, err)
-		require.NotNil(t, signerCreator)
-
-		signer, err := signerCreator.Create(&api.JSONObject{
-			Data: []byte(fmt.Sprintf(`{
-				"id": "%s",
-				"type": "Ed25519VerificationKey2018",
-				"publicKeyBase58": "%s"
-			}`, key.KeyID, base58.Encode(key.PubKey))),
-		})
-		require.NoError(t, err)
-		require.NotNil(t, signer)
-	})
-	t.Run("success - JWK verification method", func(t *testing.T) {
-		kmsStore, err := arieskms.NewAriesProviderWrapper(mem.NewProvider())
-		require.NoError(t, err)
-
-		keyManager, err := localkms.NewKMS(kmsStore)
-		require.NoError(t, err)
-
-		key, err := keyManager.Create(localkms.KeyTypeED25519)
-		require.NoError(t, err)
-
-		jwk, err := jwksupport.PubKeyBytesToJWK(key.PubKey, arieskms.ED25519Type)
-		require.NoError(t, err)
-
-		jwkBytes, err := jwk.MarshalJSON()
-		require.NoError(t, err)
-
-		signerCreator, err := localkms.NewSignerCreator(keyManager)
-		require.NoError(t, err)
-		require.NotNil(t, signerCreator)
-
-		signer, err := signerCreator.Create(&api.JSONObject{
-			Data: []byte(fmt.Sprintf(`{
-				"id": "%s",
-				"type": "JsonWebKey2020",
-				"publicKeyJwk": %s
-			}`, key.KeyID, string(jwkBytes))),
-		})
-		require.NoError(t, err)
-		require.NotNil(t, signer)
-	})
-}
-
-func newSignerCreator(t *testing.T) *localkms.SignerCreator {
+func createTestKMS(t *testing.T) *localkms.KMS {
 	t.Helper()
 
-	kms, err := localkms.NewKMS(nil)
+	kmsStore := localkms.NewMemKMSStore()
+
+	localKMS, err := localkms.NewKMS(kmsStore)
 	require.NoError(t, err)
 
-	signerCreator, err := localkms.NewSignerCreator(kms)
-	require.NoError(t, err)
-	require.NotNil(t, signerCreator)
-
-	return signerCreator
+	return localKMS
 }

--- a/cmd/wallet-sdk-gomobile/localkms/memstore.go
+++ b/cmd/wallet-sdk-gomobile/localkms/memstore.go
@@ -1,0 +1,36 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package localkms
+
+// MemKMSStore is a simple in-memory KMS store implementation.
+type MemKMSStore struct {
+	keys map[string][]byte
+}
+
+// NewMemKMSStore returns a new MemKMSStore.
+func NewMemKMSStore() *MemKMSStore {
+	return &MemKMSStore{keys: map[string][]byte{}}
+}
+
+// Put stores the given key under the given keysetID.
+func (m *MemKMSStore) Put(keysetID string, key []byte) error {
+	m.keys[keysetID] = key
+
+	return nil
+}
+
+// Get retrieves the key stored under the given keysetID.
+// The returned result indicates whether a key was found and, if so, the key bytes.
+// If a key was not found, then Result.Found will be false and no error will be returned.
+func (m *MemKMSStore) Get(keysetID string) (*Result, error) {
+	key, exists := m.keys[keysetID]
+	if !exists {
+		return &Result{Found: false}, nil
+	}
+
+	return &Result{Found: true, Key: key}, nil
+}

--- a/cmd/wallet-sdk-gomobile/localkms/signercreator_test.go
+++ b/cmd/wallet-sdk-gomobile/localkms/signercreator_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package localkms_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcutil/base58"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk/jwksupport"
+	arieskms "github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/localkms"
+)
+
+func TestSignerCreator_Create(t *testing.T) {
+	t.Run("Unmarshal failure", func(t *testing.T) {
+		signerCreator := newSignerCreator(t)
+
+		signer, err := signerCreator.Create(&api.JSONObject{})
+		require.EqualError(t, err, "failed to unmarshal verification method JSON into a did.VerificationMethod")
+		require.Nil(t, signer)
+	})
+	t.Run("fail to parse verification method JWK", func(t *testing.T) {
+		signerCreator := newSignerCreator(t)
+
+		signer, err := signerCreator.Create(&api.JSONObject{
+			Data: []byte(`{
+				"id": "foo",
+				"type": "JsonWebKey2020",
+				"publicKeyJwk": {}
+			}`),
+		})
+		require.EqualError(t, err, "failed to unmarshal verification method JSON into a did.VerificationMethod")
+		require.Nil(t, signer)
+	})
+	t.Run("Failed to create Aries signer", func(t *testing.T) {
+		signerCreator := newSignerCreator(t)
+
+		signer, err := signerCreator.Create(&api.JSONObject{Data: []byte("{}")})
+		require.EqualError(t, err, "failed to create Aries signer: parsing verification method: vm.Type '' not supported")
+		require.Nil(t, signer)
+	})
+	t.Run("success - verification method with raw key bytes", func(t *testing.T) {
+		kmsStore := localkms.NewMemKMSStore()
+
+		keyManager, err := localkms.NewKMS(kmsStore)
+		require.NoError(t, err)
+
+		key, err := keyManager.Create(localkms.KeyTypeED25519)
+		require.NoError(t, err)
+
+		signerCreator, err := localkms.NewSignerCreator(keyManager)
+		require.NoError(t, err)
+		require.NotNil(t, signerCreator)
+
+		signer, err := signerCreator.Create(&api.JSONObject{
+			Data: []byte(fmt.Sprintf(`{
+				"id": "%s",
+				"type": "Ed25519VerificationKey2018",
+				"publicKeyBase58": "%s"
+			}`, key.KeyID, base58.Encode(key.PubKey))),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+	})
+	t.Run("success - JWK verification method", func(t *testing.T) {
+		kmsStore := localkms.NewMemKMSStore()
+
+		keyManager, err := localkms.NewKMS(kmsStore)
+		require.NoError(t, err)
+
+		key, err := keyManager.Create(localkms.KeyTypeED25519)
+		require.NoError(t, err)
+
+		jwk, err := jwksupport.PubKeyBytesToJWK(key.PubKey, arieskms.ED25519Type)
+		require.NoError(t, err)
+
+		jwkBytes, err := jwk.MarshalJSON()
+		require.NoError(t, err)
+
+		signerCreator, err := localkms.NewSignerCreator(keyManager)
+		require.NoError(t, err)
+		require.NotNil(t, signerCreator)
+
+		signer, err := signerCreator.Create(&api.JSONObject{
+			Data: []byte(fmt.Sprintf(`{
+				"id": "%s",
+				"type": "JsonWebKey2020",
+				"publicKeyJwk": %s
+			}`, key.KeyID, string(jwkBytes))),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+	})
+}
+
+func newSignerCreator(t *testing.T) *localkms.SignerCreator {
+	t.Helper()
+
+	kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
+	require.NoError(t, err)
+
+	signerCreator, err := localkms.NewSignerCreator(kms)
+	require.NoError(t, err)
+	require.NotNil(t, signerCreator)
+
+	return signerCreator
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction_test.go
@@ -243,7 +243,7 @@ func getTestClientConfig(t *testing.T, activityLogger api.ActivityLogger,
 ) *openid4ci.ClientConfig {
 	t.Helper()
 
-	kms, err := localkms.NewKMS(nil)
+	kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
 	require.NoError(t, err)
 
 	signerCreator, err := localkms.CreateSignerCreator(kms)

--- a/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
@@ -10,6 +10,7 @@ import dev.trustbloc.wallet.sdk.did.Resolver
 import dev.trustbloc.wallet.sdk.ld.DocLoader
 import dev.trustbloc.wallet.sdk.walleterror.Walleterror
 import dev.trustbloc.wallet.sdk.localkms.Localkms
+import dev.trustbloc.wallet.sdk.localkms.MemKMSStore
 import dev.trustbloc.wallet.sdk.localkms.SignerCreator
 import io.flutter.plugin.common.MethodCall
 import walletsdk.openid4ci.OpenID4CI
@@ -117,7 +118,8 @@ class MainActivity : FlutterActivity() {
     }
 
     private fun initSDK() {
-        val kms = Localkms.newKMS(null)
+        val memKMSStore = MemKMSStore()
+        val kms = Localkms.newKMS(memKMSStore)
         didResolver = Resolver("")
         crypto = kms.crypto
         documentLoader = DocLoader()

--- a/demo/app/ios/Runner/flutterPlugin.swift
+++ b/demo/app/ios/Runner/flutterPlugin.swift
@@ -68,7 +68,8 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
     }
     
     private func initSDK(result: @escaping FlutterResult) {
-        kms = LocalkmsNewKMS(nil, nil)
+        let memKMSStore = LocalkmsNewMemKMSStore()
+        kms = LocalkmsNewKMS(memKMSStore, nil)
         didResolver = DidNewResolver("", nil)
         crypto = kms?.getCrypto()
         documentLoader = LdNewDocLoader()

--- a/pkg/did/creator/creator_test.go
+++ b/pkg/did/creator/creator_test.go
@@ -31,8 +31,7 @@ func (m *mockKeyHandleReader) ExportPubKey(string) ([]byte, error) {
 
 func TestNewCreator(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		localKMS, err := localkms.NewLocalKMS(&localkms.Config{})
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		didCreator, err := creator.NewCreator(localKMS, nil)
 		require.NoError(t, err)
@@ -47,8 +46,7 @@ func TestNewCreator(t *testing.T) {
 
 func TestNewCreatorWithKeyWriter(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		localKMS, err := localkms.NewLocalKMS(&localkms.Config{})
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		didCreator, err := creator.NewCreatorWithKeyWriter(localKMS)
 		require.NoError(t, err)
@@ -63,8 +61,7 @@ func TestNewCreatorWithKeyWriter(t *testing.T) {
 
 func TestNewCreatorWithKeyReader(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		localKMS, err := localkms.NewLocalKMS(&localkms.Config{})
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		didCreator, err := creator.NewCreatorWithKeyReader(localKMS)
 		require.NoError(t, err)
@@ -79,8 +76,7 @@ func TestNewCreatorWithKeyReader(t *testing.T) {
 
 func TestCreator_Create(t *testing.T) {
 	t.Run("Using KeyWriter (automatic key generation) - success", func(t *testing.T) {
-		localKMS, err := localkms.NewLocalKMS(&localkms.Config{})
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		didCreator, err := creator.NewCreatorWithKeyWriter(localKMS)
 		require.NoError(t, err)
@@ -132,8 +128,7 @@ func TestCreator_Create(t *testing.T) {
 				getKeyReturn: key,
 			}
 
-			localKMS, err := localkms.NewLocalKMS(&localkms.Config{})
-			require.NoError(t, err)
+			localKMS := createTestKMS(t)
 
 			didCreator, err := creator.NewCreator(localKMS, mockKHR)
 			require.NoError(t, err)
@@ -212,8 +207,7 @@ func TestCreator_Create(t *testing.T) {
 		})
 	})
 	t.Run("Unsupported DID method", func(t *testing.T) {
-		localKMS, err := localkms.NewLocalKMS(&localkms.Config{})
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		didCreator, err := creator.NewCreatorWithKeyWriter(localKMS)
 		require.NoError(t, err)
@@ -222,6 +216,17 @@ func TestCreator_Create(t *testing.T) {
 		testutil.RequireErrorContains(t, err, "DID method NotAValidDIDMethod not supported")
 		require.Empty(t, didDocResolution)
 	})
+}
+
+func createTestKMS(t *testing.T) *localkms.LocalKMS {
+	t.Helper()
+
+	kmsStore := localkms.NewMemKMSStore()
+
+	localKMS, err := localkms.NewLocalKMS(localkms.Config{Storage: kmsStore})
+	require.NoError(t, err)
+
+	return localKMS
 }
 
 type mockKeyWriter func(keyType kms.KeyType) (string, []byte, error)

--- a/pkg/did/creator/ion/ion_test.go
+++ b/pkg/did/creator/ion/ion_test.go
@@ -28,8 +28,7 @@ func TestNewCreator(t *testing.T) {
 
 func TestCreator_Create(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		localKMS, err := localkms.NewLocalKMS(&localkms.Config{})
-		require.NoError(t, err)
+		localKMS := createTestKMS(t)
 
 		kid, pk, err := localKMS.Create(kms.ED25519Type)
 		require.NoError(t, err)
@@ -66,6 +65,17 @@ func TestCreator_Create(t *testing.T) {
 		require.ErrorIs(t, err, expectErr)
 		require.Nil(t, doc)
 	})
+}
+
+func createTestKMS(t *testing.T) *localkms.LocalKMS {
+	t.Helper()
+
+	kmsStore := localkms.NewMemKMSStore()
+
+	localKMS, err := localkms.NewLocalKMS(localkms.Config{Storage: kmsStore})
+	require.NoError(t, err)
+
+	return localKMS
 }
 
 type mockKeyWriter func(keyType kms.KeyType) (string, []byte, error)

--- a/pkg/localkms/localkms.go
+++ b/pkg/localkms/localkms.go
@@ -35,8 +35,12 @@ type Config struct {
 }
 
 // NewLocalKMS returns a new Local KMS.
-func NewLocalKMS(cfg *Config) (*LocalKMS, error) {
-	ariesLocalKMS, err := arieslocalkms.New("ThisIs://Unused", &InMemoryStorageProvider{
+func NewLocalKMS(cfg Config) (*LocalKMS, error) {
+	if cfg.Storage == nil {
+		return nil, errors.New("cfg.Storage cannot be nil")
+	}
+
+	ariesLocalKMS, err := arieslocalkms.New("ThisIs://Unused", &storageProvider{
 		Storage: cfg.Storage,
 	})
 	if err != nil {

--- a/pkg/openid4ci/openid4ci_test.go
+++ b/pkg/openid4ci/openid4ci_test.go
@@ -558,15 +558,17 @@ func newInteraction(t *testing.T, requestURI string) *openid4ci.Interaction {
 func getTestClientConfig(t *testing.T) *openid4ci.ClientConfig {
 	t.Helper()
 
-	ariesLocalKMS, err := arieslocalkms.New("ThisIs://Unused", localkms.NewInMemoryStorageProvider())
+	localKMS, err := localkms.NewLocalKMS(localkms.Config{Storage: localkms.NewMemKMSStore()})
 	require.NoError(t, err)
 
 	tinkCrypto, err := tinkcrypto.New()
 	require.NoError(t, err)
 
-	signerProvider := didsignjwt.UseDefaultSigner(ariesLocalKMS, tinkCrypto)
+	ariesKMS := localKMS.GetAriesKMS() //nolint: staticcheck // will be removed in the future
 
-	didResolver := &mockResolver{keyWriter: ariesLocalKMS}
+	signerProvider := didsignjwt.UseDefaultSigner(ariesKMS, tinkCrypto)
+
+	didResolver := &mockResolver{keyWriter: ariesKMS}
 
 	return &openid4ci.ClientConfig{
 		UserDID:        "UserDID",

--- a/test/integration/credentialapi_test.go
+++ b/test/integration/credentialapi_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestCredentialAPI(t *testing.T) {
-	kms, e := localkms.NewKMS(nil)
+	kms, e := localkms.NewKMS(localkms.NewMemKMSStore())
 	require.NoError(t, e)
 
 	crypto := kms.GetCrypto()

--- a/test/integration/openid4ci_test.go
+++ b/test/integration/openid4ci_test.go
@@ -59,7 +59,7 @@ func TestOpenID4CIFullFlow(t *testing.T) {
 
 		println(initiateIssuanceURL)
 
-		kms, err := localkms.NewKMS(nil)
+		kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
 		require.NoError(t, err)
 
 		// create DID

--- a/test/integration/openid4vp_test.go
+++ b/test/integration/openid4vp_test.go
@@ -136,7 +136,7 @@ type vpTestHelper struct {
 }
 
 func newVPTestHelper(t *testing.T, didMethod string) *vpTestHelper {
-	kms, err := localkms.NewKMS(nil)
+	kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
 	require.NoError(t, err)
 
 	// create DID


### PR DESCRIPTION
Fixed an issue with the local KMS implementation that was causing a runtime error when using any store implementation that was injected in from mobile code. Also did some refactoring to bring the local KMS more in line with the other APIs.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>