### PR TITLE
feat(sdk): Simplify the ResolveDisplay gomobile function, add docs

### DIFF
--- a/cmd/wallet-sdk-gomobile/docs/usage.md
+++ b/cmd/wallet-sdk-gomobile/docs/usage.md
@@ -38,9 +38,9 @@ val vc = Vcparse.parse("VC JSON goes here", opts)
 
 db.add(vc)
 
-retrievedVC = db.get("VC_ID")
+val retrievedVC = db.get("VC_ID")
 
-retrievedVCs = db.getAll()
+val retrievedVCs = db.getAll()
 
 db.remove("VC_ID")
 ```
@@ -57,9 +57,9 @@ let vc = VcparseParse("VC JSON goes here", opts, nil)!
 
 db.add(vc)
 
-retrievedVC = db.get("VC_ID")
+let retrievedVC = db.get("VC_ID")
 
-retrievedVCs = db.getAll()
+let retrievedVCs = db.getAll()
 
 db.remove("VC_ID")
 ```
@@ -392,7 +392,7 @@ let issuerURI = interaction.issuerURI() // Optional (but useful)
 // Consider checking the activity log at some point after the interaction
 ```
 
-## Credential Display Data
+### Credential Display Data
 
 After completing the `RequestCredential` step of the OpenID4CI flow, you will have your issued Verifiable Credential
 objects. These objects contain the data needed for various wallet operations, but they don't tell you how you can
@@ -406,13 +406,14 @@ and pass in your preferred locale.
 calling the `issuerURI` method on an OpenID4CI interaction object. It's a good idea to store the issuer URI somewhere
 after going through the OpenID4CI flow. This way, you can call the standalone `resolveDisplay` method later if/when you
 need to refresh your display data based on the latest display information from the issuer.
+See [Resolve Display](#resolve-display) for more information.
 
 Display data objects can be serialized using the `serialize()` method (useful for storage) and parsed from serialized
 form back into display data objects using the `parseDisplayData()` function.
 
 The structure of the display data object is as follows:
 
-### `DisplayData`
+#### `DisplayData`
 
 * The root object.
 * Can be serialized using the `serialize()` method and parsed using the `parseDisplayData()` function.
@@ -420,42 +421,75 @@ The structure of the display data object is as follows:
 * Use the `credentialDisplaysLength()` and `credentialDisplayAtIndex()` methods to iterate over the `CredentialDisplay`
 objects.
 
-### `IssuerDisplay`
+#### `IssuerDisplay`
 
 * Describes display information about the issuer.
 * Can be serialized using the `serialize()` method and parsed using the `parseIssuerDisplay()` function.
 * Has `name()` and `locale()` methods.
 
-### `CredentialDisplay`
+#### `CredentialDisplay`
 
 * Describes display information about the credential.
 * Can be serialized using the `serialize()` method and parsed using the `parseCredentialDisplay()` function.
 * The `overview()` method returns the `CredentialOverview` object.
 * Use the `claimsLength()` and `claimAtIndex()` methods to iterate over the `Claim` objects.
 
-### `CredentialOverview`
+#### `CredentialOverview`
 
 * Describes display information for the credential as a whole.
 * Has `name()`, `logo()`, `backgroundColor()`, `textColor()`, and `locale()` methods. The `logo()` method returns
 a `Logo` object.
 
-### `Logo`
+#### `Logo`
 
 * Describes display information for a logo.
 * Has `url()` and `altText()` methods.
 
-### `Claim`
+#### `Claim`
 
 * Describes display information for a specific claim.
 * Has `label()`, `value()`, and `locale()` methods.
 * For example, if the UI were to display "Given Name: Alice", then `label()` would correspond to "Given Name" while
 `value()` would correspond to "Alice".
 
-### A Note about `locale()`
+#### A Note about `locale()`
 
 The locale returned by the various `locale()` methods may not be the same as the preferred locale you passed into the
 `ResolveDisplay` function under certain circumstances. For instance, if the locale you passed in wasn't available,
 then a default locale may get used instead.
+
+#### Resolve Display
+
+The following examples show how the standalone `ResolveDisplay` function can be used.
+
+##### Kotlin (Android)
+
+```kotlin
+import dev.trustbloc.wallet.sdk.api.VerifiableCredentialsArray
+import dev.trustbloc.wallet.sdk.openid4ci.Openid4ci
+
+val vc = db.get("VC_ID") // db is some CredentialReader implementation
+
+val vcArray = VerifiableCredentialsArray()
+
+vcArray.add(vc)
+
+val displayData = Openid4ci.resolveDisplay(vcArray, "Issuer_URI_Goes_Here")
+```
+
+##### Swift (iOS)
+
+```kotlin
+import Walletsdk
+
+let vc = db.get("VC_ID") // db is some CredentialReader implementation
+
+let vcArray = ApiVerifiableCredentialsArray()
+
+vcArray.add(vc)
+
+let displayData = Openid4ciResolveDisplay(vcArray, "Issuer_URI_Goes_Here")
+```
 
 ## OpenID4VP
 

--- a/cmd/wallet-sdk-gomobile/openid4ci/resolve.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/resolve.go
@@ -11,39 +11,15 @@ import (
 	goapicredentialschema "github.com/trustbloc/wallet-sdk/pkg/credentialschema"
 )
 
-// Credentials represents the different ways that credentials can be passed in to the Resolve function.
-// At most one out of VCs and Reader can be used for a given call to Resolve.
-// If reader is specified, then IDs must also be specified. The corresponding credentials will be
-// retrieved from the credentialReader.
-type Credentials struct {
-	// VCs is an array of Verifiable Credentials.
-	VCs *api.JSONArray
-	// Reader allows for access to VCs stored via some storage mechanism. This is ignored if VCs is set.
-	Reader api.CredentialReader
-	// IDs specifies which credentials should be retrieved from the reader as a JSON array of strings.
-	IDs *api.JSONArray
-}
-
-// IssuerMetadata represents the different ways that issuer metadata can be specified in the Resolve function.
-// At most one out of issuerURI and metadata can be used for a given call to Resolve.
-// Setting issuerURI will cause the Resolve function to fetch an issuer's metadata by doing a lookup on its
-// OpenID configuration endpoint. issuerURI is expected to be the base URL for the issuer.
-// Alternatively, if metadata is set, then it will be used directly.
-type IssuerMetadata struct {
-	IssuerURI string
-	Metadata  *api.JSONObject
-}
-
-// ResolveDisplay resolves display information for issued credentials based on an issuer's metadata.
+// ResolveDisplay resolves display information for issued credentials based on an issuer's metadata, which is fetched
+// using the issuer's (base) URI.
 // The CredentialDisplays in the returned DisplayData object correspond to the VCs passed in and are in the
 // same order.
-// This method requires one VC source and one issuer metadata source.
+// This method requires one or more VCs and the issuer's base URI.
 // The display values are resolved per the 27 October 2022 revision of the OpenID4CI spec:
 // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-11.2
-func ResolveDisplay(credentials *Credentials, issuerMetadata *IssuerMetadata,
-	preferredLocale string,
-) (*DisplayData, error) {
-	opts, err := prepareOpts(credentials, issuerMetadata, preferredLocale)
+func ResolveDisplay(vcs *api.VerifiableCredentialsArray, issuerURI, preferredLocale string) (*DisplayData, error) {
+	opts, err := prepareOpts(vcs, issuerURI, preferredLocale)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wallet-sdk-gomobile/openid4ci/resolveopts.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/resolveopts.go
@@ -7,160 +7,46 @@ SPDX-License-Identifier: Apache-2.0
 package openid4ci
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
-	"github.com/piprate/json-gold/ld"
-	"github.com/trustbloc/wallet-sdk/pkg/common"
-
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	goapicredentialschema "github.com/trustbloc/wallet-sdk/pkg/credentialschema"
-	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
 )
 
-// We don't check here to see if multiple conflicting options are used - that's left up to the
-// goapicredentialschema.Resolve method that get called after this function returns.
-func prepareOpts(credentials *Credentials, issuerMetadata *IssuerMetadata,
-	preferredLocale string,
+func prepareOpts(vcs *api.VerifiableCredentialsArray,
+	issuerURI, preferredLocale string,
 ) ([]goapicredentialschema.ResolveOpt, error) {
-	if credentials == nil {
+	if vcs == nil {
 		return nil, errors.New("no credentials specified")
 	}
 
-	if issuerMetadata == nil {
-		return nil, errors.New("no issuer metadata source specified")
+	if issuerURI == "" {
+		return nil, errors.New("no issuer URI specified")
 	}
 
-	var opts []goapicredentialschema.ResolveOpt
+	const minimumNumberOfOpts = 2
 
-	credentialOpts, err := prepareCredentialsOpts(credentials)
-	if err != nil {
-		return nil, err
-	}
+	opts := make([]goapicredentialschema.ResolveOpt, minimumNumberOfOpts)
 
-	opts = append(opts, credentialOpts...)
-
-	issuerMetadataOpts, err := prepareIssuerMetadataOpts(issuerMetadata, preferredLocale)
-	if err != nil {
-		return nil, err
-	}
-
-	opts = append(opts, issuerMetadataOpts...)
-
-	return opts, nil
-}
-
-func prepareCredentialsOpts(credentials *Credentials) ([]goapicredentialschema.ResolveOpt, error) {
-	var opts []goapicredentialschema.ResolveOpt
-
-	if credentials.VCs != nil && credentials.VCs.Data != nil {
-		opt, err := generateWithCredentialsOpt(credentials.VCs)
-		if err != nil {
-			return nil, err
-		}
-
-		opts = append(opts, opt)
-	}
-
-	if credentials.Reader != nil {
-		opt, err := generateWithCredentialReaderOpt(credentials)
-		if err != nil {
-			return nil, err
-		}
-
-		opts = append(opts, opt)
-	}
-
-	return opts, nil
-}
-
-func generateWithCredentialsOpt(vcs *api.JSONArray) (goapicredentialschema.ResolveOpt, error) {
-	var vcsRaw []interface{}
-
-	err := json.Unmarshal(vcs.Data, &vcsRaw)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal VCs into an array: %w", err)
-	}
-
-	var credentials []*verifiable.Credential
-
-	for _, vcRaw := range vcsRaw {
-		vcBytes, err := json.Marshal(vcRaw)
-		if err != nil {
-			return nil, err
-		}
-
-		credential, err := verifiable.ParseCredential(vcBytes,
-			verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(common.DefaultHTTPClient())),
-			verifiable.WithDisabledProofCheck())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse credential: %w", err)
-		}
-
-		credentials = append(credentials, credential)
-	}
-
-	return goapicredentialschema.WithCredentials(credentials), nil
-}
-
-func generateWithCredentialReaderOpt(credentials *Credentials) (goapicredentialschema.ResolveOpt, error) {
-	var ids []string
-
-	if credentials.IDs != nil {
-		err := json.Unmarshal(credentials.IDs.Data, &ids)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal credential IDs into a []string: %w", err)
-		}
-	}
-
-	opt := goapicredentialschema.WithCredentialReader(&wrapper.CredentialReaderWrapper{
-		CredentialReader: credentials.Reader,
-	}, ids)
-
-	return opt, nil
-}
-
-func prepareIssuerMetadataOpts(issuerMetadata *IssuerMetadata,
-	preferredLocale string,
-) ([]goapicredentialschema.ResolveOpt, error) {
-	var opts []goapicredentialschema.ResolveOpt
-
-	if issuerMetadata.IssuerURI != "" {
-		opt := goapicredentialschema.WithIssuerURI(issuerMetadata.IssuerURI)
-
-		opts = append(opts, opt)
-	}
-
-	if issuerMetadata.Metadata != nil && issuerMetadata.Metadata.Data != nil {
-		opt, err := generateWithIssuerMetadataOpt(issuerMetadata)
-		if err != nil {
-			return nil, err
-		}
-
-		opts = append(opts, opt)
-	}
+	opts[0] = goapicredentialschema.WithCredentials(mobileVCsArrayToGoAPIVCsArray(vcs))
+	opts[1] = goapicredentialschema.WithIssuerURI(issuerURI)
 
 	if preferredLocale != "" {
 		opt := goapicredentialschema.WithPreferredLocale(preferredLocale)
 
-		opts = append(opts, opt)
+		opts = append(opts, opt) //nolint:makezero // false positive
 	}
 
 	return opts, nil
 }
 
-func generateWithIssuerMetadataOpt(issuerMetadata *IssuerMetadata) (goapicredentialschema.ResolveOpt, error) {
-	var issuerMetadataParsed issuer.Metadata
+func mobileVCsArrayToGoAPIVCsArray(vcs *api.VerifiableCredentialsArray) []*verifiable.Credential {
+	goAPIVCs := make([]*verifiable.Credential, vcs.Length())
 
-	err := json.Unmarshal(issuerMetadata.Metadata.Data, &issuerMetadataParsed)
-	if err != nil {
-		return nil, err
+	for i := 0; i < vcs.Length(); i++ {
+		goAPIVCs[i] = vcs.AtIndex(i).VC
 	}
 
-	opt := goapicredentialschema.WithIssuerMetadata(&issuerMetadataParsed)
-
-	return opt, nil
+	return goAPIVCs
 }


### PR DESCRIPTION
- Simplified the gomobile ResolveDisplay function by removing unneeded options.
- Switched the gomobile ResolveDisplay function to use the VC type introduced previously instead of requiring raw JSON.
- Added documentation.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>