### PR TITLE
feat(sdk): Enable VC proof checks during OpenID4CI flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: adb reverse tcp:8075 tcp:8075 && make integration-test-flutter
+          script: adb reverse tcp:8075 tcp:8075 && adb reverse tcp:8072 tcp:8072 && make integration-test-flutter
 
   GenerateVersion:
     if: github.event_name == 'push' && (github.repository == 'trustbloc/wallet-sdk' && github.ref == 'refs/heads/main')

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
@@ -46,10 +46,11 @@ func NewCredentialRequestOpts(userPIN string) *CredentialRequestOpts {
 // ActivityLogger is optional, but if provided then activities will be logged there.
 // If not provided, then no activities will be logged.
 type ClientConfig struct {
-	ClientID       string
-	Crypto         api.Crypto
-	DIDResolver    api.DIDResolver
-	ActivityLogger api.ActivityLogger
+	ClientID             string
+	Crypto               api.Crypto
+	DIDResolver          api.DIDResolver
+	ActivityLogger       api.ActivityLogger
+	disableVCProofChecks bool
 }
 
 // NewClientConfig creates the client config object.
@@ -64,6 +65,11 @@ func NewClientConfig(clientID string, crypto api.Crypto,
 		DIDResolver:    didRes,
 		ActivityLogger: activityLogger,
 	}
+}
+
+// DisableVCProofChecks disables VC proof checks during the OpenID4CI interaction flow.
+func (c *ClientConfig) DisableVCProofChecks() {
+	c.disableVCProofChecks = true
 }
 
 // NewInteraction creates a new OpenID4CI Interaction.
@@ -164,9 +170,10 @@ func unwrapConfig(config *ClientConfig) *openid4cigoapi.ClientConfig {
 	activityLogger := createGoAPIActivityLogger(config.ActivityLogger)
 
 	return &openid4cigoapi.ClientConfig{
-		ClientID:       config.ClientID,
-		DIDResolver:    &wrapper.VDRResolverWrapper{DIDResolver: config.DIDResolver},
-		ActivityLogger: activityLogger,
+		ClientID:             config.ClientID,
+		DIDResolver:          &wrapper.VDRResolverWrapper{DIDResolver: config.DIDResolver},
+		ActivityLogger:       activityLogger,
+		DisableVCProofChecks: config.disableVCProofChecks,
 	}
 }
 

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction_test.go
@@ -294,6 +294,7 @@ func getTestClientConfig(t *testing.T, kms *localkms.KMS,
 	resolver := &mockResolver{keyWriter: kms}
 
 	clientConfig := openid4ci.NewClientConfig("ClientID", kms.GetCrypto(), resolver, activityLogger)
+	clientConfig.DisableVCProofChecks()
 
 	return clientConfig
 }

--- a/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
@@ -153,7 +153,7 @@ class MainActivity : FlutterActivity() {
     private fun initSDK() {
         val kmsLocalStore = KmsStore(context)
         val kms = Localkms.newKMS(kmsLocalStore)
-        didResolver = Resolver("")
+        didResolver = Resolver("http://localhost:8072/1.0/identifiers")
         crypto = kms.crypto
         documentLoader = DocLoader()
         activityLogger = ActivityLogger()

--- a/demo/app/ios/Runner/flutterPlugin.swift
+++ b/demo/app/ios/Runner/flutterPlugin.swift
@@ -82,7 +82,7 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
     private func initSDK(result: @escaping FlutterResult) {
         let kmsstore = kmsStore()
         kms = LocalkmsNewKMS(kmsstore, nil)
-        didResolver = DidNewResolver("", nil)
+        didResolver = DidNewResolver("http://did-resolver.trustbloc.local:8072/1.0/identifiers", nil)
         crypto = kms?.getCrypto()
         documentLoader = LdNewDocLoader()
         activityLogger = MemNewActivityLogger()

--- a/pkg/openid4ci/clientconfig.go
+++ b/pkg/openid4ci/clientconfig.go
@@ -27,9 +27,10 @@ func (d *didResolverWrapper) Resolve(did string, _ ...vdr.DIDMethodOption) (*did
 // ClientConfig contains the various parameters for an OpenID4CI Interaction.
 // TODO: https://github.com/trustbloc/wallet-sdk/issues/163 refactor to instead require a key ID and a signer.
 type ClientConfig struct {
-	ClientID       string
-	DIDResolver    api.DIDResolver
-	ActivityLogger api.ActivityLogger // If not specified, then activities won't be logged.
+	ClientID             string
+	DIDResolver          api.DIDResolver
+	ActivityLogger       api.ActivityLogger // If not specified, then activities won't be logged.
+	DisableVCProofChecks bool
 }
 
 func validateClientConfig(config *ClientConfig) error {

--- a/pkg/openid4ci/models.go
+++ b/pkg/openid4ci/models.go
@@ -16,12 +16,13 @@ import (
 // Interaction represents a single OpenID4CI interaction between a wallet and an issuer. The methods defined on this
 // object are used to help guide the calling code through the OpenID4CI flow.
 type Interaction struct {
-	initiationRequest *InitiationRequest
-	clientID          string
-	issuerMetadata    *issuer.Metadata
-	vcs               []*verifiable.Credential
-	didResolver       *didResolverWrapper
-	activityLogger    api.ActivityLogger
+	initiationRequest    *InitiationRequest
+	clientID             string
+	issuerMetadata       *issuer.Metadata
+	vcs                  []*verifiable.Credential
+	didResolver          *didResolverWrapper
+	activityLogger       api.ActivityLogger
+	disableVCProofChecks bool
 }
 
 // InitiationRequest represents the Issuance Initiation Request object received from an issuer as defined in

--- a/test/integration/fixtures/docker-compose.yml
+++ b/test/integration/fixtures/docker-compose.yml
@@ -101,9 +101,11 @@ services:
       - ALLOWED_ORIGINS=https://testnet.orb.local
       - CAS_TYPE=local
       - ANCHOR_CREDENTIAL_SIGNATURE_SUITE=Ed25519Signature2018
-      - DATABASE_TYPE=mem
+      - DATABASE_TYPE=mongodb
+      - DATABASE_URL=mongodb://mongodb.example.com:27017
       - ORB_KMS_TYPE=local
-      - KMSSECRETS_DATABASE_TYPE=mem
+      - KMSSECRETS_DATABASE_TYPE=mongodb
+      - KMSSECRETS_DATABASE_URL=mongodb://mongodb.example.com:27017
       - INCLUDE_PUBLISHED_OPERATIONS_IN_METADATA=true
       - INCLUDE_UNPUBLISHED_OPERATIONS_IN_METADATA=true
       - UNPUBLISHED_OPERATION_STORE_ENABLED=true

--- a/test/integration/openid4ci_test.go
+++ b/test/integration/openid4ci_test.go
@@ -111,7 +111,7 @@ func TestOpenID4CIFullFlow(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		didResolver, err := did.NewResolver("")
+		didResolver, err := did.NewResolver("http://did-resolver.trustbloc.local:8072/1.0/identifiers")
 		require.NoError(t, err)
 
 		didID, err := didDoc.ID()

--- a/test/integration/openid4vp_test.go
+++ b/test/integration/openid4vp_test.go
@@ -91,7 +91,7 @@ func TestOpenID4VPFullFlow(t *testing.T) {
 		initiateURL, err := setup.InitiateInteraction(tc.verifierProfileID)
 		require.NoError(t, err)
 
-		didResolver, err := did.NewResolver("")
+		didResolver, err := did.NewResolver("http://did-resolver.trustbloc.local:8072/1.0/identifiers")
 		require.NoError(t, err)
 
 		activityLogger := mem.NewActivityLogger()
@@ -189,7 +189,7 @@ func (h *vpTestHelper) issueCredentials(t *testing.T, issuerProfileIDs []string)
 		initiateIssuanceURL, err := oidc4ciSetup.InitiatePreAuthorizedIssuance(issuerProfileIDs[i])
 		require.NoError(t, err)
 
-		didResolver, err := did.NewResolver("")
+		didResolver, err := did.NewResolver("http://did-resolver.trustbloc.local:8072/1.0/identifiers")
 		require.NoError(t, err)
 
 		clientConfig := openid4ci.ClientConfig{


### PR DESCRIPTION
- Enabled VC proof checks during OpenID4CI flow.
- Added an option to disable the aforementioned proof checks. This option is useful for unit tests or debugging purposes.
- Switched integration tests from did:orb to did:ion.

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>