### PR TITLE
feat(sdk): return JWK from KMS APIs instead of raw key.

### DIFF
--- a/cmd/wallet-sdk-gomobile/api/api.go
+++ b/cmd/wallet-sdk-gomobile/api/api.go
@@ -7,6 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 // Package api defines gomobile-compatible wallet-sdk interfaces.
 package api
 
+import (
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
+)
+
 // JSONObject contains a single JSON object (not an array).
 // It's a simple wrapper around the actual JSON string. Its purpose is to help the
 // caller using the mobile bindings to understand what type of data to expect or pass in.
@@ -21,24 +25,23 @@ type JSONArray struct {
 	Data []byte
 }
 
-// KeyHandle represents a public key with associated metadata.
-type KeyHandle struct {
-	PubKey []byte `json:"key,omitempty"` // Raw bytes
-	KeyID  string `json:"keyID,omitempty"`
+// JSONWebKey holds a public key with associated metadata, in JWK format.
+type JSONWebKey struct {
+	JWK *jwk.JWK `json:"jwk,omitempty"`
 }
 
 // KeyWriter represents a type that is capable of performing operations related to key creation and storage within
 // an underlying KMS.
 type KeyWriter interface {
 	// Create creates a keyset of the given keyType and then writes it to storage.
-	// The keyID and raw public key bytes of the newly generated keyset are returned via the KeyHandle object.
-	Create(keyType string) (*KeyHandle, error)
+	// The public key JWK of the newly generated keyset is returned via the JSONWebKey object.
+	Create(keyType string) (*JSONWebKey, error)
 }
 
 // KeyReader represents a type that is capable of performing operations related to reading keys from an underlying KMS.
 type KeyReader interface {
-	// ExportPubKey returns the public key associated with the given keyID as raw bytes.
-	ExportPubKey(keyID string) ([]byte, error)
+	// ExportPubKey returns the public key associated with the given keyID as a JWK object.
+	ExportPubKey(keyID string) (*JSONWebKey, error)
 }
 
 // CreateDIDOpts represents the various options for the DIDCreator.Create method.

--- a/cmd/wallet-sdk-gomobile/api/jsonwebkey.go
+++ b/cmd/wallet-sdk-gomobile/api/jsonwebkey.go
@@ -1,0 +1,50 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
+)
+
+// Serialize returns a JSON representation of this JSONWebKey.
+func (k *JSONWebKey) Serialize() (string, error) {
+	if k.JWK == nil {
+		return "", fmt.Errorf("json web key has no data to serialize")
+	}
+
+	keyBytes, err := k.JWK.MarshalJSON()
+	if err != nil {
+		return "", fmt.Errorf("serializing json web key: %w", err)
+	}
+
+	return string(keyBytes), nil
+}
+
+// ID returns the Key ID for this JSONWebKey.
+func (k *JSONWebKey) ID() string {
+	if k.JWK == nil {
+		return ""
+	}
+
+	return k.JWK.KeyID
+}
+
+// ParseJSONWebKey parses a JSONWebKey from a JWK in JSON format.
+func ParseJSONWebKey(data string) (*JSONWebKey, error) {
+	key := &jwk.JWK{}
+
+	err := key.UnmarshalJSON([]byte(data))
+	if err != nil {
+		return nil, fmt.Errorf("parsing json web key: %w", err)
+	}
+
+	return &JSONWebKey{
+		JWK: key,
+	}, nil
+}

--- a/cmd/wallet-sdk-gomobile/api/jsonwebkey_test.go
+++ b/cmd/wallet-sdk-gomobile/api/jsonwebkey_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright Avast Software. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/go-jose/go-jose/v3"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/util/jwkkid"
+	"github.com/hyperledger/aries-framework-go/pkg/kms"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+)
+
+func TestKeyHandle(t *testing.T) {
+	pkb, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	key, err := jwkkid.BuildJWK(pkb, kms.ED25519Type)
+	require.NoError(t, err)
+
+	kid, err := jwkkid.CreateKID(pkb, kms.ED25519Type)
+	require.NoError(t, err)
+
+	key.KeyID = kid
+
+	kh := &api.JSONWebKey{
+		JWK: key,
+	}
+
+	t.Run("success", func(t *testing.T) {
+		require.Equal(t, kid, kh.ID())
+
+		keyString, e := kh.Serialize()
+		require.NoError(t, e)
+
+		require.NotEmpty(t, keyString)
+
+		newKH, e := api.ParseJSONWebKey(keyString)
+		require.NoError(t, e)
+
+		require.Equal(t, kh, newKH)
+	})
+
+	t.Run("fail to serialize", func(t *testing.T) {
+		k := &api.JSONWebKey{}
+		keyString, e := k.Serialize()
+		require.Error(t, e)
+		require.Empty(t, keyString)
+		require.Contains(t, e.Error(), "json web key has no data to serialize")
+
+		k = &api.JSONWebKey{
+			JWK: &jwk.JWK{
+				JSONWebKey: jose.JSONWebKey{
+					Key: make(chan int),
+				},
+			},
+		}
+		keyString, e = k.Serialize()
+		require.Error(t, e)
+		require.Empty(t, keyString)
+		require.Contains(t, e.Error(), "serializing json web key")
+	})
+
+	t.Run("fail to parse", func(t *testing.T) {
+		empty, e := api.ParseJSONWebKey("{{{{{")
+		require.Nil(t, empty)
+		require.Error(t, e)
+		require.Contains(t, e.Error(), "parsing json web key")
+	})
+}

--- a/cmd/wallet-sdk-gomobile/did/creator.go
+++ b/cmd/wallet-sdk-gomobile/did/creator.go
@@ -23,6 +23,8 @@ const (
 	DIDMethodKey = goapicreator.DIDMethodKey
 	// Ed25519VerificationKey2018 is a supported DID verification type.
 	Ed25519VerificationKey2018 = goapicreator.Ed25519VerificationKey2018
+	// JSONWebKey2020 is a supported DID verification type.
+	JSONWebKey2020 = goapicreator.JSONWebKey2020
 )
 
 // Creator is used for creating DID Documents using supported DID methods.

--- a/cmd/wallet-sdk-gomobile/did/keywrapper.go
+++ b/cmd/wallet-sdk-gomobile/did/keywrapper.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package did
 
 import (
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
 	arieskms "github.com/hyperledger/aries-framework-go/pkg/kms"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
@@ -18,13 +19,13 @@ type gomobileKeyWriterWrapper struct {
 	keyWriter api.KeyWriter
 }
 
-func (g *gomobileKeyWriterWrapper) Create(keyType arieskms.KeyType) (string, []byte, error) {
+func (g *gomobileKeyWriterWrapper) Create(keyType arieskms.KeyType) (string, *jwk.JWK, error) {
 	keyHandle, err := g.keyWriter.Create(string(keyType))
 	if err != nil {
 		return "", nil, err
 	}
 
-	return keyHandle.KeyID, keyHandle.PubKey, nil
+	return keyHandle.ID(), keyHandle.JWK, nil
 }
 
 // gomobileKeyReaderWrapper wraps a gomobile-compatible version of a KeyReader and translates methods calls to their
@@ -33,6 +34,11 @@ type gomobileKeyReaderWrapper struct {
 	keyReader api.KeyReader
 }
 
-func (g *gomobileKeyReaderWrapper) ExportPubKey(keyID string) ([]byte, error) {
-	return g.keyReader.ExportPubKey(keyID)
+func (g *gomobileKeyReaderWrapper) ExportPubKey(keyID string) (*jwk.JWK, error) {
+	kh, err := g.keyReader.ExportPubKey(keyID)
+	if err != nil {
+		return nil, err
+	}
+
+	return kh.JWK, nil
 }

--- a/cmd/wallet-sdk-gomobile/docs/usage.md
+++ b/cmd/wallet-sdk-gomobile/docs/usage.md
@@ -83,7 +83,8 @@ import dev.trustbloc.wallet.sdk.localkms.MemKMSStore
 val memKMSStore = MemKMSStore.MemKMSStore()
 val kms = Localkms.newKMS(memKMSStore)
 
-val keyHandle = kms.create(localkms.KeyTypeED25519)
+val jwk1 = kms.create(localkms.KeyTypeED25519)
+val jwk2 = kms.create(localkms.KeyTypeP384)
 ```
 
 #### Swift (iOS)
@@ -94,7 +95,8 @@ import Walletsdk
 let memKMSStore = LocalkmsNewMemKMSStore()
 let kms = LocalkmsNewKMS(memKMSStore, nil)
 
-let keyHandle = kms.create(LocalkmsKeyTypeED25519)
+let jwk1 = kms.create(LocalkmsKeyTypeED25519)
+let jwk2 = kms.create(LocalkmsKeyTypeP384)
 ```
 
 ## DID Creator

--- a/cmd/wallet-sdk-gomobile/localkms/localkms_test.go
+++ b/cmd/wallet-sdk-gomobile/localkms/localkms_test.go
@@ -25,8 +25,8 @@ func TestLocalKMS_Create(t *testing.T) {
 
 	keyHandle, err := localKMS.Create(localkms.KeyTypeED25519)
 	require.NoError(t, err)
-	require.NotEmpty(t, keyHandle.PubKey)
-	require.NotEmpty(t, keyHandle.KeyID)
+	require.NotNil(t, keyHandle.JWK)
+	require.NotEmpty(t, keyHandle.ID())
 }
 
 func TestLocalKMS_ExportPubKey(t *testing.T) {
@@ -34,10 +34,10 @@ func TestLocalKMS_ExportPubKey(t *testing.T) {
 
 	keyHandle, err := localKMS.Create(localkms.KeyTypeED25519)
 	require.NoError(t, err)
-	require.NotEmpty(t, keyHandle.PubKey)
-	require.NotEmpty(t, keyHandle.KeyID)
+	require.NotNil(t, keyHandle.JWK)
+	require.NotEmpty(t, keyHandle.ID())
 
-	_, err = localKMS.ExportPubKey(keyHandle.KeyID)
+	_, err = localKMS.ExportPubKey(keyHandle.ID())
 	require.Contains(t, err.Error(), "not implemented")
 }
 

--- a/cmd/wallet-sdk-gomobile/openid4vp/openid4vp_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4vp/openid4vp_test.go
@@ -15,18 +15,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/activitylogger/mem"
-
 	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/piprate/json-gold/ld"
 	"github.com/stretchr/testify/require"
-
-	"github.com/trustbloc/wallet-sdk/pkg/models"
-
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	"github.com/trustbloc/wallet-sdk/internal/testutil"
 	goapi "github.com/trustbloc/wallet-sdk/pkg/api"
+	"github.com/trustbloc/wallet-sdk/pkg/models"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/activitylogger/mem"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 )
 
 var (
@@ -188,11 +186,11 @@ func (dl *documentLoaderWrapper) LoadDocument(u string) (*api.LDDocument, error)
 }
 
 type mockKeyHandleReader struct {
-	exportPubKeyResult []byte
+	exportPubKeyResult *api.JSONWebKey
 	exportPubKeyErr    error
 }
 
-func (m *mockKeyHandleReader) ExportPubKey(string) ([]byte, error) {
+func (m *mockKeyHandleReader) ExportPubKey(string) (*api.JSONWebKey, error) {
 	return m.exportPubKeyResult, m.exportPubKeyErr
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,6 +10,7 @@ package api
 import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/jose"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/jose/jwk"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 )
@@ -18,14 +19,14 @@ import (
 // an underlying KMS.
 type KeyWriter interface {
 	// Create creates a keyset of the given keyType and then writes it to storage.
-	// The keyID and raw public key bytes of the newly generated keyset are returned.
-	Create(keyType kms.KeyType) (string, []byte, error)
+	// The keyID and public key JWK for the newly generated keyset are returned.
+	Create(keyType kms.KeyType) (string, *jwk.JWK, error)
 }
 
 // KeyReader represents a type that is capable of performing operations related to reading keys from an underlying KMS.
 type KeyReader interface {
-	// ExportPubKey returns the public key associated with the given keyID as raw bytes.
-	ExportPubKey(keyID string) ([]byte, error)
+	// ExportPubKey returns the public key associated with the given keyID as a JWK.
+	ExportPubKey(keyID string) (*jwk.JWK, error)
 }
 
 // CreateDIDOpts represents the various options for the DIDCreator.Create method.

--- a/pkg/common/jwt_signer_test.go
+++ b/pkg/common/jwt_signer_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util/jwkkid"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/stretchr/testify/require"
-
 	"github.com/trustbloc/wallet-sdk/pkg/common"
 	"github.com/trustbloc/wallet-sdk/pkg/models"
 )
@@ -58,6 +57,17 @@ func TestNewJWSSigner(t *testing.T) {
 					},
 				},
 				expectedAlg: common.EdDSA,
+			},
+			{
+				name: "VM with P384 JWK",
+				vm: &models.VerificationMethod{
+					ID:   "testKeyID",
+					Type: common.JSONWebKey2020,
+					Key: models.VerificationKey{
+						JSONWebKey: getECKey(t),
+					},
+				},
+				expectedAlg: common.ES384,
 			},
 		}
 
@@ -122,20 +132,6 @@ func TestNewJWSSigner(t *testing.T) {
 		require.Contains(t, err.Error(), "creating crypto thumbprint for JWK")
 	})
 
-	t.Run("unsupported JWK", func(t *testing.T) {
-		_, err := common.NewJWSSigner(
-			&models.VerificationMethod{
-				ID:   "testKeyID",
-				Type: common.JSONWebKey2020,
-				Key: models.VerificationKey{
-					JSONWebKey: getECKey(t),
-				},
-			},
-			&cryptoMock{})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "only Ed25519 is supported")
-	})
-
 	t.Run("Missed crypto", func(t *testing.T) {
 		_, err := common.NewJWSSigner(
 			&models.VerificationMethod{
@@ -193,7 +189,7 @@ func TestJWSSigner_Sign(t *testing.T) {
 func getECKey(t *testing.T) *jwk.JWK {
 	t.Helper()
 
-	crv := elliptic.P256()
+	crv := elliptic.P384()
 	privateKey, err := ecdsa.GenerateKey(crv, rand.Reader)
 	require.NoError(t, err)
 

--- a/pkg/did/creator/ion/ion.go
+++ b/pkg/did/creator/ion/ion.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hyperledger/aries-framework-go-ext/component/vdr/longform"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/did"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/util/jwkkid"
 	"github.com/hyperledger/aries-framework-go/pkg/framework/aries/api/vdr"
 	"github.com/hyperledger/aries-framework-go/pkg/kms"
 	"github.com/trustbloc/wallet-sdk/pkg/api"
@@ -70,12 +69,7 @@ func (d *Creator) Create(vm *did.VerificationMethod) (*did.DocResolution, error)
 }
 
 func (d *Creator) makeKey() (interface{}, error) {
-	_, pkBytes, err := d.kw.Create(kms.ECDSAP256TypeIEEEP1363)
-	if err != nil {
-		return nil, err
-	}
-
-	pkJWK, err := jwkkid.BuildJWK(pkBytes, kms.ECDSAP256TypeIEEEP1363)
+	_, pkJWK, err := d.kw.Create(kms.ECDSAP256TypeIEEEP1363)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/did/creator/key/key.go
+++ b/pkg/did/creator/key/key.go
@@ -23,10 +23,8 @@ func NewCreator() *Creator {
 }
 
 // Create creates a new did:key document using the given rawKey and verificationMethodType.
-func (d *Creator) Create(rawKey []byte, verificationMethodType string) (*did.DocResolution, error) {
-	verificationMethod := did.VerificationMethod{Value: rawKey, Type: verificationMethodType}
-
-	didDocArgument := &did.Doc{VerificationMethod: []did.VerificationMethod{verificationMethod}}
+func (d *Creator) Create(vm *did.VerificationMethod) (*did.DocResolution, error) {
+	didDocArgument := &did.Doc{VerificationMethod: []did.VerificationMethod{*vm}}
 
 	return d.vdr.Create(didDocArgument)
 }

--- a/pkg/localkms/localkms_test.go
+++ b/pkg/localkms/localkms_test.go
@@ -25,16 +25,28 @@ func TestLocalKMS_Create(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		localKMS := createTestKMS(t)
 
-		keyID, key, err := localKMS.Create(arieskms.ED25519Type)
+		keyID, pkJWK, err := localKMS.Create(arieskms.ED25519Type)
 		require.NoError(t, err)
 		require.NotEmpty(t, keyID)
-		require.NotEmpty(t, key)
+		require.NotNil(t, pkJWK)
+
+		keyID, pkJWK, err = localKMS.Create(arieskms.ECDSAP384IEEEP1363)
+		require.NoError(t, err)
+		require.NotEmpty(t, keyID)
+		require.NotNil(t, pkJWK)
 	})
 
 	t.Run("Invalid key type", func(t *testing.T) {
 		localKMS := createTestKMS(t)
 
 		_, _, err := localKMS.Create("INVALID")
+		require.Error(t, err)
+	})
+
+	t.Run("key type not supported", func(t *testing.T) {
+		localKMS := createTestKMS(t)
+
+		_, _, err := localKMS.Create(arieskms.BLS12381G2Type)
 		require.Error(t, err)
 	})
 }
@@ -44,7 +56,7 @@ func TestLocalKMS_GetKey(t *testing.T) {
 
 	key, err := localKMS.ExportPubKey("KeyID")
 	require.EqualError(t, err, "not implemented")
-	require.Empty(t, key)
+	require.Nil(t, key)
 }
 
 func TestLocalKMS_CustomStore(t *testing.T) {
@@ -55,7 +67,7 @@ func TestLocalKMS_CustomStore(t *testing.T) {
 
 	key, err := localKMS.ExportPubKey("KeyID")
 	require.EqualError(t, err, "not implemented")
-	require.Empty(t, key)
+	require.Nil(t, key)
 }
 
 func TestLocalKMS_GetCrypto(t *testing.T) {

--- a/pkg/openid4ci/openid4ci_test.go
+++ b/pkg/openid4ci/openid4ci_test.go
@@ -609,7 +609,12 @@ func getTestClientConfig(t *testing.T) *openid4ci.ClientConfig {
 
 // makeMockDoc creates a key in the given KMS and returns a mock DID Doc with a verification method.
 func makeMockDoc(keyWriter api.KeyWriter) (*did.Doc, error) {
-	_, pkb, err := keyWriter.Create(arieskms.ED25519Type)
+	_, pkJWK, err := keyWriter.Create(arieskms.ED25519Type)
+	if err != nil {
+		return nil, err
+	}
+
+	pkb, err := pkJWK.PublicKeyBytes()
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/openid4ci_test.go
+++ b/test/integration/openid4ci_test.go
@@ -47,6 +47,7 @@ func TestOpenID4CIFullFlow(t *testing.T) {
 		issuerProfileID     string
 		issuerDIDMethod     string
 		walletDIDMethod     string
+		walletKeyType       string
 		expectedIssuerURI   string
 		expectedDisplayData *openid4ci.DisplayData
 	}
@@ -58,6 +59,7 @@ func TestOpenID4CIFullFlow(t *testing.T) {
 			walletDIDMethod:     "ion",
 			expectedIssuerURI:   "http://localhost:8075/issuer/bank_issuer_jwtsd",
 			expectedDisplayData: parseDisplayData(t, expectedDisplayDataBankIssuer),
+			walletKeyType:       localkms.KeyTypeP384,
 		},
 		{
 			issuerProfileID:     "bank_issuer",
@@ -104,7 +106,9 @@ func TestOpenID4CIFullFlow(t *testing.T) {
 		c, err := did.NewCreatorWithKeyWriter(kms)
 		require.NoError(t, err)
 
-		didDoc, err := c.Create(tc.walletDIDMethod, &api.CreateDIDOpts{})
+		didDoc, err := c.Create(tc.walletDIDMethod, &api.CreateDIDOpts{
+			KeyType: tc.walletKeyType,
+		})
 		require.NoError(t, err)
 
 		didResolver, err := did.NewResolver("")


### PR DESCRIPTION
Allows support for more key types, demonstrates ECDSA P-384 usage.

Signed-off-by: Filip Burlacu <filip.burlacu@securekey.com>