### PR TITLE
feat(sdk): Improved OpenID4CI credential format handling

### DIFF
--- a/pkg/credentialschema/credentialdisplay.go
+++ b/pkg/credentialschema/credentialdisplay.go
@@ -19,7 +19,6 @@ import (
 
 const (
 	localeNotApplicable = "N/A"
-	jwtVCJSONFormatType = "jwt_vc_json"
 )
 
 func buildCredentialDisplays(vcs []*verifiable.Credential, credentialsSupported []issuer.SupportedCredential,
@@ -63,11 +62,6 @@ func buildCredentialDisplays(vcs []*verifiable.Credential, credentialsSupported 
 // The VC is considered to be a match for the supportedCredential if the VC has at least one type that's the same as
 // the type specified by the supportCredential (excluding the "VerifiableCredential" type that all VCs have).
 func haveMatchingTypes(supportedCredential *issuer.SupportedCredential, vc *verifiable.Credential) bool {
-	// Currently, our OpenID4CI implementation only supports the jwt_vc_json format.
-	if supportedCredential.Format != jwtVCJSONFormatType {
-		return false
-	}
-
 	for _, typeFromVC := range vc.Types {
 		// We expect the types in the VC and SupportedCredential to always include VerifiableCredential,
 		// so we skip this case.

--- a/pkg/credentialschema/credentialschema_test.go
+++ b/pkg/credentialschema/credentialschema_test.go
@@ -127,37 +127,19 @@ func TestResolve(t *testing.T) {
 			})
 			t.Run("Credentials supported object does not contain display info for the given VC, "+
 				"resulting in the default display being used", func(t *testing.T) {
-				t.Run("Credentials supported object doesn't have a jwt_vc_json format object", func(t *testing.T) {
-					var issuerMetadata issuer.Metadata
+				var issuerMetadata issuer.Metadata
 
-					err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
-					require.NoError(t, err)
+				err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
+				require.NoError(t, err)
 
-					issuerMetadata.CredentialsSupported[0].Format = "SomeUnknownFormat"
+				issuerMetadata.CredentialsSupported[0].Types[1] = "SomeOtherType"
 
-					resolvedDisplayData, errResolve := credentialschema.Resolve(
-						credentialschema.WithCredentials([]*verifiable.Credential{credential}),
-						credentialschema.WithIssuerMetadata(&issuerMetadata),
-						credentialschema.WithPreferredLocale("en-US"))
-					require.NoError(t, errResolve)
-					checkForDefaultDisplayData(t, resolvedDisplayData)
-				})
-				t.Run("jwt_vc_json format object doesn't have UniversityDegreeCredential in its types",
-					func(t *testing.T) {
-						var issuerMetadata issuer.Metadata
-
-						err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
-						require.NoError(t, err)
-
-						issuerMetadata.CredentialsSupported[0].Types[1] = "SomeOtherType"
-
-						resolvedDisplayData, errResolve := credentialschema.Resolve(
-							credentialschema.WithCredentials([]*verifiable.Credential{credential}),
-							credentialschema.WithIssuerMetadata(&issuerMetadata),
-							credentialschema.WithPreferredLocale("en-US"))
-						require.NoError(t, errResolve)
-						checkForDefaultDisplayData(t, resolvedDisplayData)
-					})
+				resolvedDisplayData, errResolve := credentialschema.Resolve(
+					credentialschema.WithCredentials([]*verifiable.Credential{credential}),
+					credentialschema.WithIssuerMetadata(&issuerMetadata),
+					credentialschema.WithPreferredLocale("en-US"))
+				require.NoError(t, errResolve)
+				checkForDefaultDisplayData(t, resolvedDisplayData)
 			})
 			t.Run("Credentials supported object does not have claim display info", func(t *testing.T) {
 				var issuerMetadata issuer.Metadata

--- a/pkg/openid4ci/openid4ci.go
+++ b/pkg/openid4ci/openid4ci.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	activityLogOperation      = "oidc-issuance"
-	jwtVCJSONCredentialFormat = "jwt_vc_json" //nolint:gosec // false positive
+	activityLogOperation        = "oidc-issuance"
+	jwtVCJSONCredentialFormat   = "jwt_vc_json"    //nolint:gosec // false positive
+	jwtVCJSONLDCredentialFormat = "jwt_vc_json-ld" //nolint:gosec // false positive
 )
 
 // Interaction represents a single OpenID4CI interaction between a wallet and an issuer. The methods defined on this
@@ -89,13 +90,15 @@ func NewInteraction(initiateIssuanceURI string, config *ClientConfig) (*Interact
 	credentialFormats := make([]string, len(credentialOffer.Credentials))
 
 	for i := 0; i < len(credentialOffer.Credentials); i++ {
-		if credentialOffer.Credentials[i].Format != jwtVCJSONCredentialFormat {
+		if credentialOffer.Credentials[i].Format != jwtVCJSONCredentialFormat &&
+			credentialOffer.Credentials[i].Format != jwtVCJSONLDCredentialFormat {
 			return nil, walleterror.NewValidationError(
 				module,
 				UnsupportedCredentialTypeInOfferCode,
 				UnsupportedCredentialTypeInOfferError,
 				fmt.Errorf("unsupported credential type (%s) in credential offer at index %d of "+
-					"credentials object", credentialOffer.Credentials[i].Format, i))
+					"credentials object (must be jwt_vc_json or jwt_vc_json-ld)",
+					credentialOffer.Credentials[i].Format, i))
 		}
 
 		credentialTypes[i] = credentialOffer.Credentials[i].Types

--- a/pkg/openid4ci/openid4ci_test.go
+++ b/pkg/openid4ci/openid4ci_test.go
@@ -114,7 +114,22 @@ func (m *mockIssuerServerHandler) ServeHTTP(writer http.ResponseWriter, request 
 
 func TestNewInteraction(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		newInteraction(t, createCredentialOfferIssuanceURI(t, "example.com"))
+		t.Run("Credential format is jwt_vc_json", func(t *testing.T) {
+			credentialOffer := createSampleCredentialOffer(t)
+
+			credentialOffer.Credentials[0].Format = "jwt_vc_json-ld"
+
+			credentialOfferBytes, err := json.Marshal(credentialOffer)
+			require.NoError(t, err)
+
+			credentialOfferEscaped := url.QueryEscape(string(credentialOfferBytes))
+
+			credentialOfferIssuanceURI := "openid-vc://?credential_offer=" + credentialOfferEscaped
+
+			newInteraction(t, credentialOfferIssuanceURI)
+		})
+		t.Run("Credential format is jwt_vc_json", func(t *testing.T) {
+		})
 	})
 	t.Run("Fail to parse URI", func(t *testing.T) {
 		config := getTestClientConfig(t)
@@ -213,7 +228,8 @@ func TestNewInteraction(t *testing.T) {
 
 		interaction, err := openid4ci.NewInteraction(credentialOfferIssuanceURI, getTestClientConfig(t))
 		require.EqualError(t, err, "UNSUPPORTED_CREDENTIAL_TYPE_IN_OFFER(OCI0-0006):unsupported "+
-			"credential type (UnsupportedType) in credential offer at index 0 of credentials object")
+			"credential type (UnsupportedType) in credential offer at index 0 of credentials object "+
+			"(must be jwt_vc_json or jwt_vc_json-ld)")
 		require.Nil(t, interaction)
 	})
 }


### PR DESCRIPTION
* Added support for credential offers using the jwt_vc_json-ld credential format.
* Removed format check in display resolver since the VCs passed in there could be of any format (and we don't currently have a way to check what the format is).

Signed-off-by: Derek Trider <Derek.Trider@securekey.com>
