### PR TITLE
feat(sdk): Update error handling when requesting credential from issuer

### DIFF
--- a/cmd/wallet-sdk-gomobile/docs/usage.md
+++ b/cmd/wallet-sdk-gomobile/docs/usage.md
@@ -1,6 +1,6 @@
 # SDK Usage
 
-Last updated: March 13, 2023 (commit `57cea0315411332c6af691ee2a90bc362694a1a5`)
+Last updated: March 14, 2023 (commit `7936266814445f20bcd840b94399cebaf50872c7`)
 
 This guide explains how to use this SDK in Android or iOS code.
 
@@ -473,6 +473,7 @@ let issuerURI = interaction.issuerURI() // Optional (but useful)
 | KEY_ID_NOT_CONTAIN_DID_PART(OCI1-0013) | The DID is incompatible with Wallet-SDK.                                                                                                                                                                                                                                                                                                                                                                                                            |
 | METADATA_FETCH_FAILED(OCI1-0009)       | An error occurred while doing an HTTP GET call on the issuer's OpenID credential issuer endpoint. The server may be down or have a configuration issue.<br/><br/>The issuer metadata object from the server is malformed.                                                                                                                                                                                                                           |
 | CREDENTIAL_FETCH_FAILED(OCI1-0012)     | An error occurred while doing an HTTP GET call on the issuer's credential endpoint. The server may be down or have a configuration issue.<br/><br/>The credential response object from the server is malformed.                                                                                                                                                                                                                                     |
+| CREDENTIAL_PARSE_FAILED(OCI1-0014)     | The issued credential is invalid, signed incorrectly, or could not be verified.                                                                                                                                                                                                                                                                                                                                                                     |
 
 ## Credential Display Data
 

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
@@ -122,10 +122,14 @@ func (i *Interaction) Authorize() (*AuthorizeResult, error) {
 // Relevant sections of the spec:
 // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-11.html#name-credential-endpoint
 func (i *Interaction) RequestCredential(
-	credentialRequest *CredentialRequestOpts,
+	credentialRequestOpts *CredentialRequestOpts,
 	vm *api.VerificationMethod,
 ) (*api.VerifiableCredentialsArray, error) {
-	goAPICredentialRequest := &openid4cigoapi.CredentialRequestOpts{UserPIN: credentialRequest.UserPIN}
+	if credentialRequestOpts == nil {
+		credentialRequestOpts = &CredentialRequestOpts{}
+	}
+
+	goAPICredentialRequest := &openid4cigoapi.CredentialRequestOpts{UserPIN: credentialRequestOpts.UserPIN}
 
 	signer, err := common.NewJWSSigner(vm.ToSDKVerificationMethod(), i.crypto)
 	if err != nil {

--- a/pkg/openid4ci/errors.go
+++ b/pkg/openid4ci/errors.go
@@ -24,6 +24,7 @@ const (
 	JWTSigningFailedError                  = "JWT_SIGNING_FAILED"
 	CredentialFetchFailedError             = "CREDENTIAL_FETCH_FAILED" //nolint:gosec //false positive
 	KeyIDNotContainDIDPartError            = "KEY_ID_NOT_CONTAIN_DID_PART"
+	CredentialParseError                   = "CREDENTIAL_PARSE_FAILED" //nolint:gosec //false positive
 )
 
 // Constants' names and reasons are obvious so they do not require additional comments.
@@ -43,4 +44,5 @@ const (
 	JWTSigningFailedCode
 	CredentialFetchFailedCode
 	KeyIDNotContainDIDPartCode
+	CredentialParseFailedCode
 )

--- a/pkg/openid4ci/openid4ci_test.go
+++ b/pkg/openid4ci/openid4ci_test.go
@@ -407,18 +407,17 @@ func TestInteraction_RequestCredential(t *testing.T) {
 			require.NotEmpty(t, credentials[0])
 		})
 	})
-	t.Run("Invalid user PIN", func(t *testing.T) {
+	t.Run("Missing user PIN", func(t *testing.T) {
 		config := getTestClientConfig(t)
 
 		interaction, err := openid4ci.NewInteraction(createCredentialOfferIssuanceURI(t, "example.com"), config)
 		require.NoError(t, err)
 
-		credentialRequest := &openid4ci.CredentialRequestOpts{}
-
-		credentialResponses, err := interaction.RequestCredential(credentialRequest, &jwtSignerMock{
+		credentialResponses, err := interaction.RequestCredential(nil, &jwtSignerMock{
 			keyID: mockKeyID,
 		})
-		testutil.RequireErrorContains(t, err, "invalid user PIN")
+		testutil.RequireErrorContains(t, err,
+			"the credential offer requires a user PIN, but it was not provided")
 		require.Nil(t, credentialResponses)
 	})
 	t.Run("Fail to fetch issuer's OpenID configuration", func(t *testing.T) {
@@ -642,8 +641,8 @@ func TestInteraction_RequestCredential(t *testing.T) {
 		vcs, err := interaction.RequestCredential(credentialRequest, &jwtSignerMock{
 			keyID: mockKeyID,
 		})
-		require.EqualError(t, err, "failed to parse credential from credential response at index 0: "+
-			"unmarshal new credential: unexpected end of JSON input")
+		require.EqualError(t, err, "CREDENTIAL_PARSE_FAILED(OCI1-0014):failed to parse credential from "+
+			"credential response at index 0: unmarshal new credential: unexpected end of JSON input")
 		require.Nil(t, vcs)
 	})
 	t.Run("Fail VC proof check - public key not found for issuer DID", func(t *testing.T) {
@@ -678,7 +677,8 @@ func TestInteraction_RequestCredential(t *testing.T) {
 		credentials, err := interaction.RequestCredential(credentialRequest, &jwtSignerMock{
 			keyID: mockKeyID,
 		})
-		require.EqualError(t, err, "failed to parse credential from credential response at index 0: "+
+		require.EqualError(t, err, "CREDENTIAL_PARSE_FAILED(OCI1-0014):failed to parse credential from "+
+			"credential response at index 0: "+
 			"decode new JWT credential: JWS decoding: unmarshal VC JWT claims: parse JWT: "+
 			"parse JWT from compact JWS: public key with KID d3cfd36b-4f75-4041-b416-f0a7a3c6b9f6 is not "+
 			"found for DID did:orb:uAAA:EiDpzs0hy0q0If4ZfJA1kxBQd9ed6FoBFhhqDWSiBeKaIg")


### PR DESCRIPTION
* Added an error code that gets returned if credential parsing (a significant operation) fails.
* Updated a potentially misleading error message that gets returned if a user PIN is not set.
* Added a nil check to the request credential methods to ensure that they don't panic if the SDK user fails to pass in the options object. If not set, the method defaults to an empty object (PIN will be empty).
* Updated documentation.