### PR TITLE
feat(sdk): Injectable LD document loader, better test stability

### DIFF
--- a/cmd/wallet-sdk-gomobile/api/api.go
+++ b/cmd/wallet-sdk-gomobile/api/api.go
@@ -81,7 +81,7 @@ type LDDocument struct {
 
 // LDDocumentLoader is capable of loading linked domains documents.
 type LDDocumentLoader interface {
-	LoadDocument(u string) (*LDDocument, error)
+	LoadDocument(url string) (*LDDocument, error)
 }
 
 // A Signer is capable of signing data.

--- a/cmd/wallet-sdk-gomobile/api/credentials_test.go
+++ b/cmd/wallet-sdk-gomobile/api/credentials_test.go
@@ -9,12 +9,10 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	_ "embed"
-	"net/http"
 	"testing"
 
 	afgojwt "github.com/hyperledger/aries-framework-go/pkg/doc/jwt"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
-	"github.com/piprate/json-gold/ld"
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
@@ -157,7 +155,7 @@ func TestVerifiableCredential_ClaimTypes(t *testing.T) {
 	t.Run("Claim types are in selective disclosures", func(t *testing.T) {
 		opts := []verifiable.CredentialOpt{
 			verifiable.WithDisabledProofCheck(),
-			verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+			verifiable.WithCredDisableValidation(),
 		}
 
 		universityDegreeVC, err := verifiable.ParseCredential([]byte(universityDegreeCredential), opts...)

--- a/cmd/wallet-sdk-gomobile/credential/inquirer.go
+++ b/cmd/wallet-sdk-gomobile/credential/inquirer.go
@@ -11,6 +11,7 @@ package credential
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/presexch"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
@@ -24,7 +25,6 @@ import (
 
 // Inquirer implements querying credentials using presentation definition.
 type Inquirer struct {
-	documentLoader       ld.DocumentLoader
 	goAPICredentialQuery *credentialquery.Instance
 }
 
@@ -89,14 +89,20 @@ func (vp *VerifiablePresentation) Credentials() (*api.VerifiableCredentialsArray
 }
 
 // NewInquirer returns a new Inquirer.
+// If documentLoader is set to nil, then a network-based loader will be used.
 func NewInquirer(documentLoader api.LDDocumentLoader) *Inquirer {
-	wrappedLoader := &wrapper.DocumentLoaderWrapper{
-		DocumentLoader: documentLoader,
+	var goAPIDocumentLoader ld.DocumentLoader
+
+	if documentLoader != nil {
+		goAPIDocumentLoader = &wrapper.DocumentLoaderWrapper{
+			DocumentLoader: documentLoader,
+		}
+	} else {
+		goAPIDocumentLoader = ld.NewDefaultDocumentLoader(http.DefaultClient)
 	}
 
 	return &Inquirer{
-		documentLoader:       wrappedLoader,
-		goAPICredentialQuery: credentialquery.NewInstance(wrappedLoader),
+		goAPICredentialQuery: credentialquery.NewInstance(goAPIDocumentLoader),
 	}
 }
 

--- a/cmd/wallet-sdk-gomobile/credential/inquirer_test.go
+++ b/cmd/wallet-sdk-gomobile/credential/inquirer_test.go
@@ -45,6 +45,13 @@ var (
 	verifiedEmployeeVC []byte
 )
 
+func TestNewInquirer(t *testing.T) {
+	t.Run("Using the default network-based document loader", func(t *testing.T) {
+		inquirer := credential.NewInquirer(nil)
+		require.NotNil(t, inquirer)
+	})
+}
+
 func TestInstance_Query(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		query := credential.NewInquirer(&documentLoaderReverseWrapper{

--- a/cmd/wallet-sdk-gomobile/credential/memstorage.go
+++ b/cmd/wallet-sdk-gomobile/credential/memstorage.go
@@ -9,28 +9,19 @@ SPDX-License-Identifier: Apache-2.0
 package credential
 
 import (
-	"net/http"
-
-	"github.com/piprate/json-gold/ld"
-
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	goapimemstorage "github.com/trustbloc/wallet-sdk/pkg/memstorage"
 )
 
 // A DB allows for credential storage and retrieval using in-memory storage only.
 type DB struct {
-	goAPIProvider  *goapimemstorage.Provider
-	documentLoader ld.DocumentLoader
+	goAPIProvider *goapimemstorage.Provider
 }
 
 // NewInMemoryDB returns a new in-memory credential DB.
-// It uses a network-based JSON-LD document loader.
-// TODO: https://github.com/trustbloc/wallet-sdk/issues/160 Support custom document
-// loaders so that contexts can be preloaded.
 func NewInMemoryDB() *DB {
 	return &DB{
-		goAPIProvider:  goapimemstorage.NewProvider(),
-		documentLoader: ld.NewDefaultDocumentLoader(http.DefaultClient),
+		goAPIProvider: goapimemstorage.NewProvider(),
 	}
 }
 

--- a/cmd/wallet-sdk-gomobile/credential/signer.go
+++ b/cmd/wallet-sdk-gomobile/credential/signer.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/piprate/json-gold/ld"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	"github.com/trustbloc/wallet-sdk/pkg/credentialsigner"
@@ -18,8 +17,7 @@ import (
 
 // Signer issues self-signed credentials.
 type Signer struct {
-	signer   *credentialsigner.Signer
-	ldLoader ld.DocumentLoader
+	signer *credentialsigner.Signer
 }
 
 // NewSigner initializes a credential Signer for issuing self-signed credentials.
@@ -29,15 +27,13 @@ func NewSigner(
 	crypto api.Crypto,
 	ldLoader api.LDDocumentLoader,
 ) (*Signer, error) {
-	ldLoaderWrapper := &wrapper.DocumentLoaderWrapper{DocumentLoader: ldLoader}
 	readerWrapper := &wrapper.CredentialReaderWrapper{CredentialReader: credReader}
 	resolverWrapper := &wrapper.VDRResolverWrapper{DIDResolver: didResolver}
 
 	sdkSigner := credentialsigner.New(readerWrapper, resolverWrapper, crypto)
 
 	return &Signer{
-		signer:   sdkSigner,
-		ldLoader: ldLoaderWrapper,
+		signer: sdkSigner,
 	}, nil
 }
 

--- a/cmd/wallet-sdk-gomobile/docs/usage.md
+++ b/cmd/wallet-sdk-gomobile/docs/usage.md
@@ -1,6 +1,6 @@
 # SDK Usage
 
-Last updated: March 14, 2023 (commit `7936266814445f20bcd840b94399cebaf50872c7`)
+Last updated: March 23, 2023 (commit `ed04b7c22c0634e62f58a40597ebd3e967835b61`)
 
 This guide explains how to use this SDK in Android or iOS code.
 
@@ -120,7 +120,15 @@ let opts = VcparseNewOpts(false, nil)
 let vc = VcparseParse("Serialized VC goes here", opts, nil)
 ```
 
+## LD Document Loading
+
+Several APIs allow for an LD document loader to be specified.
+If no custom LD document loader is specified (or is nil/null), then network-based document loading will be used instead.
+For performance and/or security reasons, you may wish to implement a custom LD document loader that uses
+preloaded local contexts.
+
 ## In-Memory Credential Storage
+
 The credential package contains an in-memory credential storage implementation that can be used to store credentials
 in memory and also satisfy the credential reader interface. As it only uses in-memory storage, you will probably want to
 create your own implementation in your mobile code that uses platform-specific storage.

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
@@ -53,6 +53,7 @@ type ClientConfig struct {
 	disableVCProofChecks             bool
 	additionalHeaders                api.Headers
 	disableHTTPClientTLSVerification bool
+	documentLoader                   api.LDDocumentLoader
 }
 
 // NewClientConfig creates the client config object.
@@ -86,6 +87,12 @@ func (c *ClientConfig) AddHeaders(headers *api.Headers) {
 // DisableHTTPClientTLSVerify disables tls verification, should be used only for test purposes.
 func (c *ClientConfig) DisableHTTPClientTLSVerify() {
 	c.disableHTTPClientTLSVerification = true
+}
+
+// SetDocumentLoader sets the document loader to use when parsing VCs received from the issuer.
+// If no document loader is explicitly set, then a network-based loader will be used.
+func (c *ClientConfig) SetDocumentLoader(documentLoader api.LDDocumentLoader) {
+	c.documentLoader = documentLoader
 }
 
 // NewInteraction creates a new OpenID4CI Interaction.
@@ -185,6 +192,14 @@ func unwrapConfig(config *ClientConfig) *openid4cigoapi.ClientConfig {
 		MetricsLogger:        &wrapper.MobileMetricsLoggerWrapper{MobileAPIMetricsLogger: config.MetricsLogger},
 		DisableVCProofChecks: config.disableVCProofChecks,
 		HTTPClient:           httpClient,
+	}
+
+	if config.documentLoader != nil {
+		documentLoaderWrapper := &wrapper.DocumentLoaderWrapper{
+			DocumentLoader: config.documentLoader,
+		}
+
+		goAPIClientConfig.DocumentLoader = documentLoaderWrapper
 	}
 
 	return goAPIClientConfig

--- a/cmd/wallet-sdk-gomobile/wrapper/documentloaderwrapper.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/documentloaderwrapper.go
@@ -22,8 +22,8 @@ type DocumentLoaderWrapper struct {
 }
 
 // LoadDocument wraps LoadDocument of api.LDDocumentLoader.
-func (l *DocumentLoaderWrapper) LoadDocument(u string) (*ld.RemoteDocument, error) {
-	doc, err := l.DocumentLoader.LoadDocument(u)
+func (l *DocumentLoaderWrapper) LoadDocument(url string) (*ld.RemoteDocument, error) {
+	doc, err := l.DocumentLoader.LoadDocument(url)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wallet-sdk-gomobile/wrapper/documentloaderwrapper_test.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/documentloaderwrapper_test.go
@@ -47,7 +47,7 @@ func TestDocumentLoaderWrapper_LoadDocument(t *testing.T) {
 		require.Contains(t, err.Error(), "load failed")
 	})
 
-	t.Run("DOc parse failed", func(t *testing.T) {
+	t.Run("Doc parse failed", func(t *testing.T) {
 		documentLoaderWrapper := wrapper.DocumentLoaderWrapper{
 			DocumentLoader: &documentLoaderMock{
 				LoadResult: &api.LDDocument{
@@ -69,6 +69,6 @@ type documentLoaderMock struct {
 	LoadErr    error
 }
 
-func (d *documentLoaderMock) LoadDocument(u string) (*api.LDDocument, error) {
+func (d *documentLoaderMock) LoadDocument(string) (*api.LDDocument, error) {
 	return d.LoadResult, d.LoadErr
 }

--- a/pkg/credentialschema/credentialschema_test.go
+++ b/pkg/credentialschema/credentialschema_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/trustbloc/wallet-sdk/pkg/memstorage"
 
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
-	"github.com/piprate/json-gold/ld"
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/wallet-sdk/pkg/credentialschema"
@@ -59,7 +58,7 @@ func TestResolve(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		t.Run("Credentials supported object contains display info for the given VC", func(t *testing.T) {
 			credential, err := verifiable.ParseCredential(credentialUniversityDegree,
-				verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+				verifiable.WithCredDisableValidation(),
 				verifiable.WithDisabledProofCheck())
 			require.NoError(t, err)
 
@@ -231,7 +230,7 @@ func TestResolve(t *testing.T) {
 			})
 			t.Run("VC does not have the subject fields specified by the claim display info", func(t *testing.T) {
 				credential, err := verifiable.ParseCredential(credentialUniversityDegree,
-					verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+					verifiable.WithCredDisableValidation(),
 					verifiable.WithDisabledProofCheck())
 				require.NoError(t, err)
 
@@ -273,7 +272,7 @@ func TestResolve(t *testing.T) {
 
 		t.Run("Correctly shown display info for selective disclosure JWT", func(t *testing.T) {
 			credential, err := verifiable.ParseCredential(credentialVerifiedEmployeeSD,
-				verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+				verifiable.WithCredDisableValidation(),
 				verifiable.WithDisabledProofCheck())
 			require.NoError(t, err)
 
@@ -341,7 +340,7 @@ func TestResolve(t *testing.T) {
 	t.Run("Unsupported VC", func(t *testing.T) {
 		t.Run("Unsupported subject type", func(t *testing.T) {
 			credential, err := verifiable.ParseCredential(unsupportedCredentialStringSubject,
-				verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+				verifiable.WithCredDisableValidation(),
 				verifiable.WithDisabledProofCheck())
 			require.NoError(t, err)
 
@@ -359,7 +358,7 @@ func TestResolve(t *testing.T) {
 		})
 		t.Run("Multiple subjects", func(t *testing.T) {
 			credential, err := verifiable.ParseCredential(unsupportedCredentialMultipleSubjects,
-				verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+				verifiable.WithCredDisableValidation(),
 				verifiable.WithDisabledProofCheck())
 			require.NoError(t, err)
 
@@ -378,7 +377,7 @@ func TestResolve(t *testing.T) {
 	})
 	t.Run("Fail to compile regex", func(t *testing.T) {
 		credential, err := verifiable.ParseCredential(credentialUniversityDegree,
-			verifiable.WithJSONLDDocumentLoader(ld.NewDefaultDocumentLoader(http.DefaultClient)),
+			verifiable.WithCredDisableValidation(),
 			verifiable.WithDisabledProofCheck())
 		require.NoError(t, err)
 

--- a/pkg/openid4vp/openid4vp.go
+++ b/pkg/openid4vp/openid4vp.go
@@ -86,6 +86,10 @@ func New(
 ) *Interaction {
 	client, activityLogger, metricsLogger := processOpts(opts)
 
+	if documentLoader == nil {
+		documentLoader = ld.NewDefaultDocumentLoader(http.DefaultClient)
+	}
+
 	return &Interaction{
 		authorizationRequest: authorizationRequest,
 		signatureVerifier:    signatureVerifier,

--- a/test/integration/credentialapi_test.go
+++ b/test/integration/credentialapi_test.go
@@ -9,11 +9,8 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
-
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/metricslogger/stderr"
 
 	diddoc "github.com/hyperledger/aries-framework-go/pkg/doc/did"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/util"
@@ -26,6 +23,8 @@ import (
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/credential"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/did"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/localkms"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/metricslogger/stderr"
+	"github.com/trustbloc/wallet-sdk/internal/testutil"
 	sdkapi "github.com/trustbloc/wallet-sdk/pkg/api"
 	"github.com/trustbloc/wallet-sdk/pkg/did/resolver"
 )
@@ -38,7 +37,7 @@ func TestCredentialAPI(t *testing.T) {
 
 	credStore := credential.NewInMemoryDB()
 
-	ldLoader := ld.NewDefaultDocumentLoader(http.DefaultClient)
+	ldLoader := testutil.DocumentLoader(t)
 
 	ldLoaderWrapper := &documentLoaderReverseWrapper{DocumentLoader: ldLoader}
 
@@ -149,8 +148,8 @@ type documentLoaderReverseWrapper struct {
 	DocumentLoader ld.DocumentLoader
 }
 
-func (l *documentLoaderReverseWrapper) LoadDocument(u string) (*api.LDDocument, error) {
-	doc, err := l.DocumentLoader.LoadDocument(u)
+func (l *documentLoaderReverseWrapper) LoadDocument(url string) (*api.LDDocument, error) {
+	doc, err := l.DocumentLoader.LoadDocument(url)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/openid4ci_test.go
+++ b/test/integration/openid4ci_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/credential"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/did"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/display"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/localkms"
-	"github.com/trustbloc/wallet-sdk/test/integration/pkg/helpers"
-
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/did"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/openid4ci"
+	"github.com/trustbloc/wallet-sdk/internal/testutil"
+	"github.com/trustbloc/wallet-sdk/test/integration/pkg/helpers"
 	"github.com/trustbloc/wallet-sdk/test/integration/pkg/setup/oidc4ci"
 	"github.com/trustbloc/wallet-sdk/test/integration/pkg/testenv"
 )
@@ -169,6 +169,8 @@ func TestOpenID4CIFullFlow(t *testing.T) {
 			Crypto:         testHelper.KMS.GetCrypto(),
 			MetricsLogger:  testHelper.MetricsLogger,
 		}
+
+		clientConfig.SetDocumentLoader(&documentLoaderReverseWrapper{DocumentLoader: testutil.DocumentLoader(t)})
 
 		interaction, err := openid4ci.NewInteraction(offerCredentialURL, &clientConfig)
 		require.NoError(t, err)

--- a/test/integration/openid4vp_test.go
+++ b/test/integration/openid4vp_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/credential"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/did"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/ld"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/localkms"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/openid4vp"
+	"github.com/trustbloc/wallet-sdk/internal/testutil"
 	"github.com/trustbloc/wallet-sdk/test/integration/pkg/helpers"
 	"github.com/trustbloc/wallet-sdk/test/integration/pkg/metricslogger"
 	"github.com/trustbloc/wallet-sdk/test/integration/pkg/setup/oidc4vp"
@@ -135,7 +135,7 @@ func TestOpenID4VPFullFlow(t *testing.T) {
 
 		activityLogger := mem.NewActivityLogger()
 
-		docLoader := ld.NewDocLoader()
+		docLoader := &documentLoaderReverseWrapper{DocumentLoader: testutil.DocumentLoader(t)}
 
 		metricsLogger := metricslogger.NewMetricsLogger()
 


### PR DESCRIPTION
* LD document loaders can now be injected wherever LD document loaders are used.
* Updated default document loader across the SDK to be consistent: now, whenever a document loader is not specified (or is nil), a network-based loader will be used by default.
* Updated docs to described this new default LD loader behaviour.
* Updated unit tests and BDD tests to ensure they never use a network-based loader in order to improve test reliability and performance. Now, tests either have document loading disabled or use pre-loaded contexts. Note that Flutter tests will still use network-based loading for the time being.

closes #160