### PR TITLE
fix(sdk)!: Removed the ToMobileError function from mobile bindings

### DIFF
--- a/cmd/wallet-sdk-gomobile/credential/inquirer.go
+++ b/cmd/wallet-sdk-gomobile/credential/inquirer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/piprate/json-gold/ld"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	"github.com/trustbloc/wallet-sdk/pkg/credentialquery"
 )
@@ -84,7 +83,7 @@ func (c *Inquirer) Query(query []byte, credentials *CredentialsArg) (*Verifiable
 		}),
 	)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return wrapVerifiablePresentation(presentation), err
@@ -105,7 +104,7 @@ func (c *Inquirer) GetSubmissionRequirements(query []byte, credentials *Credenti
 		}),
 	)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return &SubmissionRequirementArray{wrapped: requirements}, nil

--- a/cmd/wallet-sdk-gomobile/did/create.go
+++ b/cmd/wallet-sdk-gomobile/did/create.go
@@ -12,7 +12,6 @@ import (
 	arieskms "github.com/hyperledger/aries-framework-go/pkg/kms"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	goapi "github.com/trustbloc/wallet-sdk/pkg/api"
 	goapicreator "github.com/trustbloc/wallet-sdk/pkg/did/creator"
@@ -36,12 +35,12 @@ func create(method, keyID string, goAPICreator *goapicreator.Creator, opts *Crea
 
 	didDocResolution, err := goAPICreator.Create(method, goAPIOpts)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	didDocResolutionBytes, err := didDocResolution.JSONBytes()
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return &api.DIDDocResolution{Content: string(didDocResolutionBytes)}, nil

--- a/cmd/wallet-sdk-gomobile/did/creator.go
+++ b/cmd/wallet-sdk-gomobile/did/creator.go
@@ -12,7 +12,7 @@ import (
 	"errors"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	goapicreator "github.com/trustbloc/wallet-sdk/pkg/did/creator"
 )
 
@@ -41,7 +41,7 @@ func NewCreator(keyWriter api.KeyWriter) (*Creator, error) {
 
 	goAPICreator, err := goapicreator.NewCreatorWithKeyWriter(gomobileKeyWriterWrapper)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return &Creator{

--- a/cmd/wallet-sdk-gomobile/did/creatorwithkeyreader.go
+++ b/cmd/wallet-sdk-gomobile/did/creatorwithkeyreader.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	goapicreator "github.com/trustbloc/wallet-sdk/pkg/did/creator"
 )
 
@@ -30,7 +30,7 @@ func NewCreatorWithKeyReader(keyReader api.KeyReader) (*CreatorWithKeyReader, er
 
 	goAPIDIDCreator, err := goapicreator.NewCreatorWithKeyReader(gomobileKeyReaderWrapper)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return &CreatorWithKeyReader{

--- a/cmd/wallet-sdk-gomobile/did/resolver.go
+++ b/cmd/wallet-sdk-gomobile/did/resolver.go
@@ -10,7 +10,7 @@ package did
 import (
 	// helps gomobile bind api.DIDResolver interface to Resolver implementation in ios-bindings.
 	_ "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	"github.com/trustbloc/wallet-sdk/pkg/did/resolver"
 )
 
@@ -27,7 +27,7 @@ func NewResolver(opts *ResolverOpts) (*Resolver, error) {
 
 	didResolver, err := resolver.NewDIDResolver(opts.resolverServerURI)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return &Resolver{resolver: didResolver}, nil
@@ -37,7 +37,7 @@ func NewResolver(opts *ResolverOpts) (*Resolver, error) {
 func (d *Resolver) Resolve(did string) ([]byte, error) {
 	didDocResolution, err := d.resolver.Resolve(did)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return didDocResolution.JSONBytes()

--- a/cmd/wallet-sdk-gomobile/did/wellknown.go
+++ b/cmd/wallet-sdk-gomobile/did/wellknown.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hyperledger/aries-framework-go/pkg/client/didconfig"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	goapiwellknown "github.com/trustbloc/wallet-sdk/pkg/did/wellknown"
 )
@@ -45,7 +44,7 @@ func validateLinkedDomains(did string, resolver api.DIDResolver,
 
 	valid, uri, err := goapiwellknown.ValidateLinkedDomains(did, vdrWrapper, client)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return &ValidationResult{IsValid: valid, ServiceURL: uri}, nil

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
@@ -54,7 +54,7 @@ func NewInteraction(args *Args, opts *Opts) (*Interaction, error) {
 
 	goAPIInteraction, err := openid4cigoapi.NewInteraction(args.initiateIssuanceURI, goAPIClientConfig)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	return &Interaction{
@@ -72,7 +72,7 @@ func NewInteraction(args *Args, opts *Opts) (*Interaction, error) {
 func (i *Interaction) Authorize() (*AuthorizeResult, error) {
 	authorizationResultGoAPI, err := i.goAPIInteraction.Authorize()
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	authorizationResult := &AuthorizeResult{
@@ -129,14 +129,14 @@ func (i *Interaction) requestCredential(
 
 	signer, err := common.NewJWSSigner(vm.ToSDKVerificationMethod(), i.crypto)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	goAPICredentialRequest := &openid4cigoapi.CredentialRequestOpts{UserPIN: pin}
 
 	credentials, err := i.goAPIInteraction.RequestCredential(goAPICredentialRequest, signer)
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	gomobileCredentials := api.NewVerifiableCredentialsArray()

--- a/cmd/wallet-sdk-gomobile/openid4vp/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4vp/interaction.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/credential"
-	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
 	"github.com/trustbloc/wallet-sdk/pkg/common"
 	"github.com/trustbloc/wallet-sdk/pkg/openid4vp"
@@ -106,12 +105,12 @@ func NewInteraction(args *Args, opts *Opts) *Interaction {
 func (o *Interaction) GetQuery() ([]byte, error) {
 	presentationDefinition, err := o.goAPIOpenID4VP.GetQuery()
 	if err != nil {
-		return nil, walleterror.ToMobileError(err)
+		return nil, wrapper.ToMobileError(err)
 	}
 
 	pdBytes, err := json.Marshal(presentationDefinition)
 	if err != nil {
-		return nil, walleterror.ToMobileError(
+		return nil, wrapper.ToMobileError(
 			fmt.Errorf("presentation definition marshal: %w", err))
 	}
 
@@ -120,7 +119,7 @@ func (o *Interaction) GetQuery() ([]byte, error) {
 
 // PresentCredential presents credentials to redirect uri from request object.
 func (o *Interaction) PresentCredential(credentials *api.VerifiableCredentialsArray) error {
-	return walleterror.ToMobileError(o.goAPIOpenID4VP.PresentCredential(unwrapVCs(credentials)))
+	return wrapper.ToMobileError(o.goAPIOpenID4VP.PresentCredential(unwrapVCs(credentials)))
 }
 
 func unwrapVCs(vcs *api.VerifiableCredentialsArray) []*verifiable.Credential {

--- a/cmd/wallet-sdk-gomobile/walleterror/error.go
+++ b/cmd/wallet-sdk-gomobile/walleterror/error.go
@@ -9,10 +9,6 @@ package walleterror
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
-
-	"github.com/trustbloc/wallet-sdk/pkg/walleterror"
 )
 
 // Error represents error returned by go mobile api.
@@ -20,38 +16,6 @@ type Error struct {
 	Code     string `json:"code"`
 	Category string `json:"category"`
 	Details  string `json:"details"`
-}
-
-// ToMobileError translates go api errors to go mobile errors.
-func ToMobileError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	var result *Error
-
-	var walletError *walleterror.Error
-
-	if errors.As(err, &walletError) {
-		result = &Error{
-			Code:     walletError.Code,
-			Category: walletError.Scenario,
-			Details:  walletError.ParentError,
-		}
-	} else {
-		result = &Error{
-			Code:     "UKN2-000",
-			Category: "UNEXPECTED_ERROR",
-			Details:  err.Error(),
-		}
-	}
-
-	formatted, fmtErr := json.Marshal(result)
-	if fmtErr != nil {
-		return fmt.Errorf("unexpected format error: %w", fmtErr)
-	}
-
-	return errors.New(string(formatted))
 }
 
 // Parse used to parse exception message on mobile side.

--- a/cmd/wallet-sdk-gomobile/wrapper/error.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/error.go
@@ -1,0 +1,48 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wrapper
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
+	goapiwalleterror "github.com/trustbloc/wallet-sdk/pkg/walleterror"
+)
+
+// ToMobileError translates Go API errors to gomobile API errors.
+func ToMobileError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var result *walleterror.Error
+
+	var walletError *goapiwalleterror.Error
+
+	if errors.As(err, &walletError) {
+		result = &walleterror.Error{
+			Code:     walletError.Code,
+			Category: walletError.Scenario,
+			Details:  walletError.ParentError,
+		}
+	} else {
+		result = &walleterror.Error{
+			Code:     "UKN2-000",
+			Category: "UNEXPECTED_ERROR",
+			Details:  err.Error(),
+		}
+	}
+
+	formatted, fmtErr := json.Marshal(result)
+	if fmtErr != nil {
+		return fmt.Errorf("failed to marshal error: %w", fmtErr)
+	}
+
+	return errors.New(string(formatted))
+}

--- a/cmd/wallet-sdk-gomobile/wrapper/error_test.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/error_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package wrapper_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
+	goapiwalleterror "github.com/trustbloc/wallet-sdk/pkg/walleterror"
+)
+
+func TestToMobileError(t *testing.T) {
+	t.Run("Nil error", func(t *testing.T) {
+		err := wrapper.ToMobileError(nil)
+		require.NoError(t, err)
+	})
+	t.Run("Wallet error passed in", func(t *testing.T) {
+		walletError := &goapiwalleterror.Error{
+			Code:        "Code",
+			Scenario:    "Category",
+			ParentError: "Details",
+		}
+
+		err := wrapper.ToMobileError(walletError)
+		require.Error(t, err)
+
+		parsedErr := walleterror.Parse(err.Error())
+
+		require.Equal(t, "Code", parsedErr.Code)
+		require.Equal(t, "Category", parsedErr.Category)
+		require.Equal(t, "Details", parsedErr.Details)
+	})
+	t.Run("goapiwalleterror.Error passed in", func(t *testing.T) {
+		walletError := &goapiwalleterror.Error{
+			Code:        "Code",
+			Scenario:    "Category",
+			ParentError: "Details",
+		}
+
+		err := wrapper.ToMobileError(walletError)
+		require.Error(t, err)
+
+		parsedErr := walleterror.Parse(err.Error())
+
+		require.Equal(t, "Code", parsedErr.Code)
+		require.Equal(t, "Category", parsedErr.Category)
+		require.Equal(t, "Details", parsedErr.Details)
+	})
+	t.Run("Non-goapiwalleterror.Error passed in", func(t *testing.T) {
+		goErr := errors.New("regular Go error")
+
+		err := wrapper.ToMobileError(goErr)
+		require.Error(t, err)
+
+		parsedErr := walleterror.Parse(err.Error())
+
+		require.Equal(t, "UKN2-000", parsedErr.Code)
+		require.Equal(t, "UNEXPECTED_ERROR", parsedErr.Category)
+		require.Equal(t, "regular Go error", parsedErr.Details)
+	})
+}


### PR DESCRIPTION
Moved the ToMobileError function from the walleterror package into the wrapper package. This causes it to not be exposed in the bindings since the wrapper package is excluded. This was done since ToMobileError shouldn't be exposed as it's intended to only be used internally.