### PR TITLE
ci(app): upgrade gradle action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,7 +145,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v2.4.2
       - name: AVD cache
         uses: actions/cache@v3
         id: avd-cache


### PR DESCRIPTION
closes https://github.com/trustbloc/wallet-sdk/issues/431