### PR TITLE
feat(app): Add support for multi auth code args from the issuer

### DIFF
--- a/demo/app/ios/Runner/OpenID4CI.swift
+++ b/demo/app/ios/Runner/OpenID4CI.swift
@@ -42,12 +42,27 @@ public class OpenID4CI {
         return ""
     }
     
-    func getAuthorizationLink(scope1: String, scope2: String, clientID: String, redirectURI: String) throws  -> String {
-     let scopes = ApiStringArray()
-      scopes!.append(scope1)!.append(scope2)
+    func getAuthorizationLink(scopes: [String], clientID: String, redirectURI: String) throws  -> String {
+     let scopesArr = ApiStringArray()
+        for scope in scopes {
+            scopesArr!.append(scope)!
+        }
+
       var error: NSError?
     
-       let authorizationLink =  initiatedInteraction.createAuthorizationURL(withScopes: clientID, redirectURI: redirectURI, scopes: scopes, error: &error)
+       let authorizationLink =  initiatedInteraction.createAuthorizationURL(withScopes: clientID, redirectURI: redirectURI, scopes: scopesArr, error: &error)
+        if let actualError = error {
+            print("error in authorizations", error!.localizedDescription)
+            throw actualError
+       }
+        
+      return authorizationLink
+    }
+    
+    func getAuthorizationLinkWithoutScopes(clientID: String, redirectURI: String) throws  -> String {
+      var error: NSError?
+    
+        let authorizationLink =  initiatedInteraction.createAuthorizationURL(clientID, redirectURI: redirectURI, error: &error)
         if let actualError = error {
             print("error in authorizations", error!.localizedDescription)
             throw actualError

--- a/demo/app/ios/Runner/flutterPlugin.swift
+++ b/demo/app/ios/Runner/flutterPlugin.swift
@@ -310,13 +310,18 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
             }
             
             if (flowType == "auth-code-flow"){
-                guard let authCodeArgs = arguments["authCodeArgs"] as? Dictionary<String, String> else {
+                guard let authCodeArgs = arguments["authCodeArgs"] as? Dictionary<String, Any> else {
                     return  result(FlutterError.init(code: "NATIVE_ERR",
                                                      message: "error while reading auth code argments",
                                                      details: "Pass scopes, clientID and redirectURI as the arguments"))
                 }
                 
-                authorizationLink = try openID4CI.getAuthorizationLink(scope1: authCodeArgs["scope1"]!, scope2: authCodeArgs["scope2"]!, clientID: authCodeArgs["clientID"]!, redirectURI: authCodeArgs["redirectURI"]!)
+                if (!authCodeArgs.keys.contains("scopes")) {
+                    authorizationLink = try openID4CI.getAuthorizationLinkWithoutScopes(clientID: authCodeArgs["clientID"]! as! String, redirectURI: authCodeArgs["redirectURI"]! as! String)
+                } else {
+                    authorizationLink = try openID4CI.getAuthorizationLink(scopes: authCodeArgs["scopes"]! as! [String], clientID: authCodeArgs["clientID"]! as! String, redirectURI: authCodeArgs["redirectURI"]! as! String)
+                }
+      
             }
             
             var flowTypeData :[String:Any] = [

--- a/demo/app/lib/assets/issuerAuthFlowConfig.json
+++ b/demo/app/lib/assets/issuerAuthFlowConfig.json
@@ -1,0 +1,20 @@
+{
+  "https://api-gateway.dev.trustbloc.dev/issuer/bank_issuer/v1.0":
+    {
+      "scopes": ["openid","profile"],
+      "clientID": "oidc4vc_client",
+      "redirectURI": "trustbloc-wallet://openid4vci/authcodeflow/callback"
+    },
+  "https://api-gateway.dev.trustbloc.dev/issuer/pr_card_issuer_jwtsd/v1.0":
+  {
+    "scopes": ["openid","profile"],
+    "clientID": "oidc4vc_client",
+    "redirectURI": "trustbloc-wallet://openid4vci/authcodeflow/callback"
+  },
+  "https://api-gateway.dev.trustbloc.dev/issuer/vaccination_certificate_issuer/v1.0":
+  {
+    "scopes": ["openid","profile"],
+    "clientID": "oidc4vc_client",
+    "redirectURI": "trustbloc-wallet://openid4vci/authcodeflow/callback"
+  }
+}

--- a/demo/app/lib/demo_method_channel.dart
+++ b/demo/app/lib/demo_method_channel.dart
@@ -99,7 +99,7 @@ class MethodChannelWallet extends WalletPlatform {
     return fetchDIDMsg;
   }
 
-  Future<Map<Object?, Object?>?> initialize(String qrCode, Map<String, String>? authCodeArgs) async {
+  Future<Map<Object?, Object?>?> initialize(String qrCode, Map<String, dynamic>? authCodeArgs) async {
     try {
       final flowTypeData =
       await methodChannel.invokeMethod('initialize', <String, dynamic>{'requestURI': qrCode, 'authCodeArgs': authCodeArgs});

--- a/demo/app/pubspec.yaml
+++ b/demo/app/pubspec.yaml
@@ -87,6 +87,7 @@ flutter:
    - lib/assets/images/credLogo.png
    - lib/assets/images/errorVector.png
    - lib/assets/images/success.png
+   - lib/assets/issuerAuthFlowConfig.json
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
- This pr also have a logic in place if any issuer don't need scope to function, we will call without  scope method from sdk to get the authorization link. 
- Config file is added to get the auth code flow arguments 
- Removed the scope 1 and scope 2 parameters added array of scope support instead
