### PR TITLE
feat(sdk): OAuth2 Dynamic Client Registration API

### DIFF
--- a/cmd/wallet-sdk-gomobile/api/api.go
+++ b/cmd/wallet-sdk-gomobile/api/api.go
@@ -8,15 +8,6 @@ SPDX-License-Identifier: Apache-2.0
 // Package api defines gomobile-compatible wallet-sdk interfaces.
 package api
 
-import (
-	"github.com/hyperledger/aries-framework-go/component/kmscrypto/doc/jose/jwk"
-)
-
-// JSONWebKey holds a public key with associated metadata, in JWK format.
-type JSONWebKey struct {
-	JWK *jwk.JWK `json:"jwk,omitempty"`
-}
-
 // KeyWriter represents a type that is capable of performing operations related to key creation and storage within
 // an underlying KMS.
 type KeyWriter interface {

--- a/cmd/wallet-sdk-gomobile/api/jsonwebkey.go
+++ b/cmd/wallet-sdk-gomobile/api/jsonwebkey.go
@@ -12,6 +12,11 @@ import (
 	"github.com/hyperledger/aries-framework-go/component/kmscrypto/doc/jose/jwk"
 )
 
+// JSONWebKey holds a public key with associated metadata, in JWK format.
+type JSONWebKey struct {
+	JWK *jwk.JWK `json:"jwk,omitempty"`
+}
+
 // Serialize returns a JSON representation of this JSONWebKey.
 func (k *JSONWebKey) Serialize() (string, error) {
 	if k.JWK == nil {
@@ -47,4 +52,39 @@ func ParseJSONWebKey(data string) (*JSONWebKey, error) {
 	return &JSONWebKey{
 		JWK: key,
 	}, nil
+}
+
+// JSONWebKeySet represents a JWK Set object.
+type JSONWebKeySet struct {
+	JWKs []JSONWebKey
+}
+
+// NewJSONWebKeySet returns a new JSON Web Key Set.
+// It acts as a gomobile-compatible wrapper around a Go array of JSONWebKey objects.
+func NewJSONWebKeySet() *JSONWebKeySet {
+	return &JSONWebKeySet{}
+}
+
+// Append appends the given JSONWebKey to the array.
+// It returns a reference to the JSONWebKey in order to allow a caller to chain together Append calls.
+func (j *JSONWebKeySet) Append(jsonWebKey *JSONWebKey) *JSONWebKeySet {
+	j.JWKs = append(j.JWKs, *jsonWebKey)
+
+	return j
+}
+
+// Length returns the number of JSONWebKeys contained within this JSONWebKeySet object.
+func (j *JSONWebKeySet) Length() int {
+	return len(j.JWKs)
+}
+
+// AtIndex returns the JSONWebKey at the given index.
+// If the index passed in is out of bounds, then nil is returned.
+func (j *JSONWebKeySet) AtIndex(index int) *JSONWebKey {
+	maxIndex := len(j.JWKs) - 1
+	if index > maxIndex || index < 0 {
+		return nil
+	}
+
+	return &j.JWKs[index]
 }

--- a/cmd/wallet-sdk-gomobile/api/jsonwebkey_test.go
+++ b/cmd/wallet-sdk-gomobile/api/jsonwebkey_test.go
@@ -48,6 +48,12 @@ func TestKeyHandle(t *testing.T) {
 		require.NoError(t, e)
 
 		require.Equal(t, kh, newKH)
+
+		jwks := api.NewJSONWebKeySet()
+		jwks.Append(kh)
+
+		require.Equal(t, 1, jwks.Length())
+		require.Equal(t, kh, jwks.AtIndex(0))
 	})
 
 	t.Run("fail to serialize", func(t *testing.T) {

--- a/cmd/wallet-sdk-gomobile/oauth2/clientmetadata.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientmetadata.go
@@ -1,0 +1,206 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oauth2
+
+import (
+	"github.com/hyperledger/aries-framework-go/component/kmscrypto/doc/jose/jwk"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+	goapi "github.com/trustbloc/wallet-sdk/pkg/api"
+	goapioauth2 "github.com/trustbloc/wallet-sdk/pkg/oauth2"
+)
+
+// ClientMetadata represents a set of client metadata values.
+type ClientMetadata struct {
+	goAPIClientMetadata *goapioauth2.ClientMetadata
+}
+
+// NewClientMetadata creates a new ClientMetadata object.
+func NewClientMetadata() *ClientMetadata {
+	return &ClientMetadata{goAPIClientMetadata: &goapioauth2.ClientMetadata{}}
+}
+
+// RedirectURIs returns the redirect URIs.
+func (c *ClientMetadata) RedirectURIs() *api.StringArray {
+	return &api.StringArray{Strings: c.goAPIClientMetadata.RedirectURIs}
+}
+
+// SetRedirectURIs sets the redirect URIs.
+func (c *ClientMetadata) SetRedirectURIs(redirectURIs *api.StringArray) {
+	if redirectURIs == nil {
+		redirectURIs = api.NewStringArray()
+	}
+
+	c.goAPIClientMetadata.RedirectURIs = redirectURIs.Strings
+}
+
+// TokenEndpointAuthMethod returns the token endpoint authentication method.
+func (c *ClientMetadata) TokenEndpointAuthMethod() string {
+	return c.goAPIClientMetadata.TokenEndpointAuthMethod
+}
+
+// SetTokenEndpointAuthMethod sets the token endpoint authentication method.
+func (c *ClientMetadata) SetTokenEndpointAuthMethod(tokenEndpointAuthMethod string) {
+	c.goAPIClientMetadata.TokenEndpointAuthMethod = tokenEndpointAuthMethod
+}
+
+// GrantTypes returns the grant types.
+func (c *ClientMetadata) GrantTypes() *api.StringArray {
+	return &api.StringArray{Strings: c.goAPIClientMetadata.GrantTypes}
+}
+
+// SetGrantTypes sets the grant types.
+func (c *ClientMetadata) SetGrantTypes(grantTypes *api.StringArray) {
+	if grantTypes == nil {
+		grantTypes = api.NewStringArray()
+	}
+
+	c.goAPIClientMetadata.GrantTypes = grantTypes.Strings
+}
+
+// ResponseTypes returns the response types.
+func (c *ClientMetadata) ResponseTypes() *api.StringArray {
+	return &api.StringArray{Strings: c.goAPIClientMetadata.ResponseTypes}
+}
+
+// SetResponseTypes sets the response types.
+func (c *ClientMetadata) SetResponseTypes(responseTypes *api.StringArray) {
+	if responseTypes == nil {
+		responseTypes = api.NewStringArray()
+	}
+
+	c.goAPIClientMetadata.ResponseTypes = responseTypes.Strings
+}
+
+// ClientName returns the client name.
+func (c *ClientMetadata) ClientName() string {
+	return c.goAPIClientMetadata.ClientName
+}
+
+// SetClientName sets the client name.
+func (c *ClientMetadata) SetClientName(clientName string) {
+	c.goAPIClientMetadata.ClientName = clientName
+}
+
+// ClientURI returns the client URI.
+func (c *ClientMetadata) ClientURI() string {
+	return c.goAPIClientMetadata.ClientURI
+}
+
+// SetClientURI sets the client URI.
+func (c *ClientMetadata) SetClientURI(clientURI string) {
+	c.goAPIClientMetadata.ClientURI = clientURI
+}
+
+// LogoURI returns the logo URI.
+func (c *ClientMetadata) LogoURI() string {
+	return c.goAPIClientMetadata.LogoURI
+}
+
+// SetLogoURI sets the logo URI.
+func (c *ClientMetadata) SetLogoURI(logoURI string) {
+	c.goAPIClientMetadata.LogoURI = logoURI
+}
+
+// Scope returns the scope.
+func (c *ClientMetadata) Scope() string {
+	return c.goAPIClientMetadata.Scope
+}
+
+// SetScope sets the scope types.
+func (c *ClientMetadata) SetScope(scope string) {
+	c.goAPIClientMetadata.Scope = scope
+}
+
+// Contacts returns the contacts.
+func (c *ClientMetadata) Contacts() *api.StringArray {
+	return &api.StringArray{Strings: c.goAPIClientMetadata.Contacts}
+}
+
+// SetContacts sets the contacts.
+func (c *ClientMetadata) SetContacts(contacts *api.StringArray) {
+	if contacts == nil {
+		contacts = api.NewStringArray()
+	}
+
+	c.goAPIClientMetadata.Contacts = contacts.Strings
+}
+
+// TOSURI returns the TOS (terms of service) document URI.
+func (c *ClientMetadata) TOSURI() string {
+	return c.goAPIClientMetadata.TOSURI
+}
+
+// SetTOSURI sets the TOS (terms of service) document URI.
+func (c *ClientMetadata) SetTOSURI(tosURI string) {
+	c.goAPIClientMetadata.TOSURI = tosURI
+}
+
+// PolicyURI returns the privacy policy document URI.
+func (c *ClientMetadata) PolicyURI() string {
+	return c.goAPIClientMetadata.PolicyURI
+}
+
+// SetPolicyURI sets the privacy policy document URI.
+func (c *ClientMetadata) SetPolicyURI(policyURI string) {
+	c.goAPIClientMetadata.PolicyURI = policyURI
+}
+
+// JWKSetURI returns the JWK Set document URI.
+func (c *ClientMetadata) JWKSetURI() string {
+	return c.goAPIClientMetadata.JWKSetURI
+}
+
+// SetJWKSetURI sets the JWK Set document URI.
+func (c *ClientMetadata) SetJWKSetURI(jwksURI string) {
+	c.goAPIClientMetadata.JWKSetURI = jwksURI
+}
+
+// JWKSet returns the JWK Set document value. If the client metadata doesn't have one, then nil is returned instead.
+func (c *ClientMetadata) JWKSet() *api.JSONWebKeySet {
+	if c.goAPIClientMetadata.JWKSet == nil {
+		return nil
+	}
+
+	jsonWebKeySet := api.JSONWebKeySet{JWKs: make([]api.JSONWebKey, len(c.goAPIClientMetadata.JWKSet.JWKs))}
+
+	for i := range c.goAPIClientMetadata.JWKSet.JWKs {
+		jsonWebKeySet.JWKs[i] = api.JSONWebKey{JWK: &c.goAPIClientMetadata.JWKSet.JWKs[i]}
+	}
+
+	return &jsonWebKeySet
+}
+
+// SetJWKSet sets the JWK Set document value.
+func (c *ClientMetadata) SetJWKSet(jwks *api.JSONWebKeySet) {
+	goAPIJSONWebKeySet := goapi.JSONWebKeySet{JWKs: make([]jwk.JWK, len(jwks.JWKs))}
+
+	for i := range jwks.JWKs {
+		goAPIJSONWebKeySet.JWKs[i] = *jwks.JWKs[i].JWK
+	}
+
+	c.goAPIClientMetadata.JWKSet = &goAPIJSONWebKeySet
+}
+
+// SoftwareID returns the software ID.
+func (c *ClientMetadata) SoftwareID() string {
+	return c.goAPIClientMetadata.SoftwareID
+}
+
+// SetSoftwareID sets the software ID.
+func (c *ClientMetadata) SetSoftwareID(softwareID string) {
+	c.goAPIClientMetadata.SoftwareID = softwareID
+}
+
+// SoftwareVersion returns the software version.
+func (c *ClientMetadata) SoftwareVersion() string {
+	return c.goAPIClientMetadata.SoftwareVersion
+}
+
+// SetSoftwareVersion sets the software version.
+func (c *ClientMetadata) SetSoftwareVersion(softwareVersion string) {
+	c.goAPIClientMetadata.SoftwareVersion = softwareVersion
+}

--- a/cmd/wallet-sdk-gomobile/oauth2/clientmetadata_test.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientmetadata_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oauth2_test
+
+import (
+	"testing"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/oauth2"
+)
+
+func TestClientMetadata(t *testing.T) {
+	clientMetadata := oauth2.NewClientMetadata()
+
+	clientMetadata.SetRedirectURIs(nil)
+	require.Equal(t, 0, clientMetadata.RedirectURIs().Length())
+
+	redirectURIs := &api.StringArray{Strings: []string{"RedirectURI1"}}
+	clientMetadata.SetRedirectURIs(redirectURIs)
+	require.Equal(t, 1, clientMetadata.RedirectURIs().Length())
+	require.Equal(t, "RedirectURI1", clientMetadata.RedirectURIs().AtIndex(0))
+
+	clientMetadata.SetTokenEndpointAuthMethod("TokenEndpointAuthMethod")
+	require.Equal(t, "TokenEndpointAuthMethod", clientMetadata.TokenEndpointAuthMethod())
+
+	clientMetadata.SetGrantTypes(nil)
+	require.Equal(t, 0, clientMetadata.GrantTypes().Length())
+
+	grantTypes := &api.StringArray{Strings: []string{"GrantType1"}}
+	clientMetadata.SetGrantTypes(grantTypes)
+	require.Equal(t, 1, clientMetadata.GrantTypes().Length())
+	require.Equal(t, "GrantType1", clientMetadata.GrantTypes().AtIndex(0))
+
+	clientMetadata.SetResponseTypes(nil)
+	require.Equal(t, 0, clientMetadata.ResponseTypes().Length())
+
+	responseTypes := &api.StringArray{Strings: []string{"ResponseType1"}}
+	clientMetadata.SetResponseTypes(responseTypes)
+	require.Equal(t, 1, clientMetadata.ResponseTypes().Length())
+	require.Equal(t, "ResponseType1", clientMetadata.ResponseTypes().AtIndex(0))
+
+	clientMetadata.SetClientName("ClientName")
+	require.Equal(t, "ClientName", clientMetadata.ClientName())
+
+	clientMetadata.SetClientURI("ClientURI")
+	require.Equal(t, "ClientURI", clientMetadata.ClientURI())
+
+	clientMetadata.SetLogoURI("LogoURI")
+	require.Equal(t, "LogoURI", clientMetadata.LogoURI())
+
+	clientMetadata.SetScope("Scope")
+	require.Equal(t, "Scope", clientMetadata.Scope())
+
+	clientMetadata.SetContacts(nil)
+	require.Equal(t, 0, clientMetadata.Contacts().Length())
+
+	contacts := &api.StringArray{Strings: []string{"Contact1"}}
+	clientMetadata.SetContacts(contacts)
+	require.Equal(t, 1, clientMetadata.Contacts().Length())
+	require.Equal(t, "Contact1", clientMetadata.Contacts().AtIndex(0))
+
+	clientMetadata.SetTOSURI("TOSURI")
+	require.Equal(t, "TOSURI", clientMetadata.TOSURI())
+
+	clientMetadata.SetPolicyURI("PolicyURI")
+	require.Equal(t, "PolicyURI", clientMetadata.PolicyURI())
+
+	clientMetadata.SetJWKSetURI("JWKSetURI")
+	require.Equal(t, "JWKSetURI", clientMetadata.JWKSetURI())
+
+	jwks := api.NewJSONWebKeySet()
+	clientMetadata.SetJWKSet(jwks)
+	require.NotNil(t, clientMetadata.JWKSet())
+
+	clientMetadata.SetSoftwareID("SoftwareID")
+	require.Equal(t, "SoftwareID", clientMetadata.SoftwareID())
+
+	clientMetadata.SetSoftwareVersion("SoftwareVersion")
+	require.Equal(t, "SoftwareVersion", clientMetadata.SoftwareVersion())
+}

--- a/cmd/wallet-sdk-gomobile/oauth2/clientregistration.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientregistration.go
@@ -1,0 +1,42 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package oauth2 provides a client API for doing OAuth2 dynamic client registration per RFC7591:
+// https://datatracker.ietf.org/doc/html/rfc7591
+package oauth2
+
+import (
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
+	goapioauth2 "github.com/trustbloc/wallet-sdk/pkg/oauth2"
+)
+
+// RegisterClient registers a new client at the given registration endpoint.
+// If the server requires an initial access token, then use RegisterClientWithInitialAccessToken instead.
+func RegisterClient(registrationEndpoint string, clientMetadata *ClientMetadata,
+	opts *RegisterClientOpts,
+) (*RegisterClientResponse, error) {
+	// Technically, all fields are optional, so if the caller passes in nil then we will assume that they want to
+	// send an empty object to the server
+	if clientMetadata == nil {
+		clientMetadata = NewClientMetadata()
+	}
+
+	if opts == nil {
+		opts = NewRegisterClientOpts()
+	}
+
+	httpClient := wrapper.NewHTTPClient(opts.httpTimeout, opts.additionalHeaders, opts.disableHTTPClientTLSVerification)
+
+	registerClientResponse, err := goapioauth2.RegisterClient(registrationEndpoint,
+		clientMetadata.goAPIClientMetadata,
+		goapioauth2.WithInitialAccessBearerToken(opts.initialAccessBearerToken),
+		goapioauth2.WithHTTPClient(httpClient))
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegisterClientResponse{goAPIRegisterClientResponse: registerClientResponse}, nil
+}

--- a/cmd/wallet-sdk-gomobile/oauth2/clientregistration_test.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientregistration_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oauth2_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	goapi "github.com/trustbloc/wallet-sdk/pkg/api"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/oauth2"
+	goapioauth2 "github.com/trustbloc/wallet-sdk/pkg/oauth2"
+)
+
+type mockIssuerServerHandler struct {
+	t *testing.T
+}
+
+func (m *mockIssuerServerHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	response := goapioauth2.RegisterClientResponse{
+		ClientID:              "ClientID",
+		ClientSecret:          "ClientSecret",
+		ClientIDIssuedAt:      10,
+		ClientSecretExpiresAt: 10,
+		ClientMetadata: &goapioauth2.ClientMetadata{
+			RedirectURIs:            []string{"RedirectURI1"},
+			TokenEndpointAuthMethod: "TokenEndpointAuthMethod",
+			GrantTypes:              []string{"GrantType1"},
+			ResponseTypes:           []string{"ResponseType1"},
+			ClientName:              "ClientName",
+			ClientURI:               "ClientURI",
+			LogoURI:                 "LogoURI",
+			Scope:                   "Scope",
+			Contacts:                []string{"Contact1"},
+			TOSURI:                  "TOSURI",
+			PolicyURI:               "PolicyURI",
+			JWKSetURI:               "JWKSetURI",
+			JWKSet:                  &goapi.JSONWebKeySet{},
+			SoftwareID:              "SoftwareID",
+			SoftwareVersion:         "SoftwareVersion",
+		},
+	}
+
+	responseBytes, err := json.Marshal(response)
+	require.NoError(m.t, err)
+
+	w.WriteHeader(http.StatusCreated)
+
+	_, err = w.Write(responseBytes)
+	require.NoError(m.t, err)
+}
+
+func TestRegisterClient(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		issuerServerHandler := &mockIssuerServerHandler{
+			t: t,
+		}
+
+		server := httptest.NewServer(issuerServerHandler)
+		defer server.Close()
+
+		opts := oauth2.NewRegisterClientOpts()
+		opts.SetHTTPTimeoutNanoseconds(int64(time.Minute))
+		opts.DisableHTTPClientTLSVerify()
+
+		testHeader := api.NewHeader("test", "test")
+		testHeaders := api.NewHeaders()
+		testHeaders.Add(testHeader)
+
+		opts.AddHeaders(testHeaders)
+		opts.AddHeader(testHeader)
+
+		t.Run("Success - without initial access token", func(t *testing.T) {
+			response, err := oauth2.RegisterClient(server.URL, &oauth2.ClientMetadata{}, opts)
+			require.NoError(t, err)
+			require.Equal(t, "ClientID", response.ClientID())
+			require.Equal(t, "ClientSecret", response.ClientSecret())
+			require.Equal(t, 10, response.ClientIDIssuedAt())
+			require.Equal(t, 10, response.ClientSecretExpiresAt())
+
+			require.True(t, response.HasClientMetadata())
+			clientMetadata, err := response.ClientMetadata()
+			require.NoError(t, err)
+
+			require.Equal(t, 1, clientMetadata.RedirectURIs().Length())
+			require.Equal(t, "RedirectURI1", clientMetadata.RedirectURIs().AtIndex(0))
+			require.Equal(t, "TokenEndpointAuthMethod", clientMetadata.TokenEndpointAuthMethod())
+			require.Equal(t, 1, clientMetadata.GrantTypes().Length())
+			require.Equal(t, "GrantType1", clientMetadata.GrantTypes().AtIndex(0))
+			require.Equal(t, 1, clientMetadata.ResponseTypes().Length())
+			require.Equal(t, "ResponseType1", clientMetadata.ResponseTypes().AtIndex(0))
+			require.Equal(t, "ClientName", clientMetadata.ClientName())
+			require.Equal(t, "ClientURI", clientMetadata.ClientURI())
+			require.Equal(t, "LogoURI", clientMetadata.LogoURI())
+			require.Equal(t, "Scope", clientMetadata.Scope())
+			require.Equal(t, 1, clientMetadata.Contacts().Length())
+			require.Equal(t, "Contact1", clientMetadata.Contacts().AtIndex(0))
+			require.Equal(t, "TOSURI", clientMetadata.TOSURI())
+			require.Equal(t, "PolicyURI", clientMetadata.PolicyURI())
+			require.Equal(t, "JWKSetURI", clientMetadata.JWKSetURI())
+			require.NotNil(t, clientMetadata.JWKSet())
+			require.Equal(t, "SoftwareID", clientMetadata.SoftwareID())
+			require.Equal(t, "SoftwareVersion", clientMetadata.SoftwareVersion())
+		})
+		t.Run("Success - with initial access token", func(t *testing.T) {
+			response, err := oauth2.RegisterClient(server.URL, &oauth2.ClientMetadata{},
+				oauth2.NewRegisterClientOpts().SetInitialAccessBearerToken("token"))
+			require.NoError(t, err)
+			require.NotEmpty(t, response)
+		})
+	})
+	t.Run("Blank registration endpoint", func(t *testing.T) {
+		response, err := oauth2.RegisterClient("", nil, nil)
+		require.EqualError(t, err, "registration endpoint cannot be blank")
+		require.Nil(t, response)
+	})
+}

--- a/cmd/wallet-sdk-gomobile/oauth2/opts.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/opts.go
@@ -1,0 +1,69 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oauth2
+
+import (
+	"time"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+)
+
+// RegisterClientOpts contains all optional arguments that can be passed into the RegisterClient and
+// RegisterClientWithInitialAccessToken functions.
+type RegisterClientOpts struct {
+	initialAccessBearerToken         string
+	additionalHeaders                api.Headers
+	disableHTTPClientTLSVerification bool
+	httpTimeout                      *time.Duration
+}
+
+// NewRegisterClientOpts returns a new RegisterClientOpts object.
+func NewRegisterClientOpts() *RegisterClientOpts {
+	return &RegisterClientOpts{}
+}
+
+// SetInitialAccessBearerToken is an option for the RegisterClient function that allows a caller to set an
+// access bearer token to use for the client registration request, which may be required by the server.
+func (o *RegisterClientOpts) SetInitialAccessBearerToken(token string) *RegisterClientOpts {
+	o.initialAccessBearerToken = token
+
+	return o
+}
+
+// SetHTTPTimeoutNanoseconds sets the timeout (in nanoseconds) for HTTP calls.
+// Passing in 0 will disable timeouts.
+func (o *RegisterClientOpts) SetHTTPTimeoutNanoseconds(timeout int64) *RegisterClientOpts {
+	timeoutDuration := time.Duration(timeout)
+	o.httpTimeout = &timeoutDuration
+
+	return o
+}
+
+// AddHeaders adds the given HTTP headers to all REST calls made to the issuer during the OpenID4CI flow.
+func (o *RegisterClientOpts) AddHeaders(headers *api.Headers) *RegisterClientOpts {
+	headersAsArray := headers.GetAll()
+
+	for i := range headersAsArray {
+		o.additionalHeaders.Add(&headersAsArray[i])
+	}
+
+	return o
+}
+
+// AddHeader adds the given HTTP header to all REST calls made to the issuer during the OpenID4CI flow.
+func (o *RegisterClientOpts) AddHeader(header *api.Header) *RegisterClientOpts {
+	o.additionalHeaders.Add(header)
+
+	return o
+}
+
+// DisableHTTPClientTLSVerify disables tls verification, should be used only for test purposes.
+func (o *RegisterClientOpts) DisableHTTPClientTLSVerify() *RegisterClientOpts {
+	o.disableHTTPClientTLSVerification = true
+
+	return o
+}

--- a/cmd/wallet-sdk-gomobile/oauth2/registerclientresponse.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/registerclientresponse.go
@@ -1,0 +1,54 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oauth2
+
+import (
+	"errors"
+
+	goapioauth2 "github.com/trustbloc/wallet-sdk/pkg/oauth2"
+)
+
+// RegisterClientResponse represents a response to a new client registration request.
+type RegisterClientResponse struct {
+	goAPIRegisterClientResponse *goapioauth2.RegisterClientResponse
+}
+
+// ClientID returns the client ID.
+func (r *RegisterClientResponse) ClientID() string {
+	return r.goAPIRegisterClientResponse.ClientID
+}
+
+// ClientSecret returns the client secret.
+func (r *RegisterClientResponse) ClientSecret() string {
+	return r.goAPIRegisterClientResponse.ClientSecret
+}
+
+// ClientIDIssuedAt returns the time at which the client ID was issued.
+func (r *RegisterClientResponse) ClientIDIssuedAt() int {
+	return r.goAPIRegisterClientResponse.ClientIDIssuedAt
+}
+
+// ClientSecretExpiresAt returns the time at which the client secret will expire or 0 if it will not expire.
+func (r *RegisterClientResponse) ClientSecretExpiresAt() int {
+	return r.goAPIRegisterClientResponse.ClientSecretExpiresAt
+}
+
+// HasClientMetadata indicates whether this RegisterClientResponse has client metadata.
+func (r *RegisterClientResponse) HasClientMetadata() bool {
+	return r.goAPIRegisterClientResponse.ClientMetadata != nil
+}
+
+// ClientMetadata returns the ClientMetadata object. The HasClientMetadata method should be called first to
+// ensure this RegisterClientResponse object has any client metadata first before calling this method.
+// If this RegisterClientResponse has no client metadata, then this method returns an error.
+func (r *RegisterClientResponse) ClientMetadata() (*ClientMetadata, error) {
+	if !r.HasClientMetadata() {
+		return nil, errors.New("the register client response object has no client metadata")
+	}
+
+	return &ClientMetadata{goAPIClientMetadata: r.goAPIRegisterClientResponse.ClientMetadata}, nil
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
@@ -192,6 +192,19 @@ func (i *Interaction) AuthorizationCodeGrantTypeSupported() bool {
 	return i.goAPIInteraction.AuthorizationCodeGrantTypeSupported()
 }
 
+// DynamicClientRegistrationSupported indicates whether the issuer supports dynamic client registration.
+func (i *Interaction) DynamicClientRegistrationSupported() (bool, error) {
+	return i.goAPIInteraction.DynamicClientRegistrationSupported()
+}
+
+// DynamicClientRegistrationEndpoint returns the issuer's dynamic client registration endpoint.
+// The caller should call the DynamicClientRegistrationSupported method first and only call this method
+// if DynamicClientRegistrationSupported returns true.
+// This method will return an error if the issuer does not support dynamic client registration.
+func (i *Interaction) DynamicClientRegistrationEndpoint() (string, error) {
+	return i.goAPIInteraction.DynamicClientRegistrationEndpoint()
+}
+
 // OTelTraceID returns open telemetry trace id.
 func (i *Interaction) OTelTraceID() string {
 	traceID := ""

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction_test.go
@@ -333,7 +333,7 @@ func TestInteraction_RequestCredential(t *testing.T) {
 	})
 }
 
-func TestInteraction_IssuerCapabilities(t *testing.T) {
+func TestInteraction_GrantTypes(t *testing.T) {
 	kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
 	require.NoError(t, err)
 
@@ -348,6 +348,25 @@ func TestInteraction_IssuerCapabilities(t *testing.T) {
 	require.True(t, preAuthorizedCodeGrantParams.PINRequired())
 
 	require.False(t, interaction.AuthorizationCodeGrantTypeSupported())
+}
+
+func TestInteraction_DynamicClientRegistration(t *testing.T) {
+	kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
+	require.NoError(t, err)
+
+	interaction := createInteraction(t, kms, nil, createTestRequestURI("example.com"), nil, false)
+
+	supported, err := interaction.DynamicClientRegistrationSupported()
+	require.EqualError(t, err, "ISSUER_OPENID_FETCH_FAILED(OCI1-0006):failed to fetch issuer's "+
+		"OpenID configuration: "+`openid configuration endpoint: Get "example.com/.well-known/openid-configuration"`+
+		`: unsupported protocol scheme ""`)
+	require.False(t, supported)
+
+	endpoint, err := interaction.DynamicClientRegistrationEndpoint()
+	require.EqualError(t, err, "ISSUER_OPENID_FETCH_FAILED(OCI1-0006):failed to fetch issuer's "+
+		"OpenID configuration: "+`openid configuration endpoint: Get "example.com/.well-known/openid-configuration"`+
+		`: unsupported protocol scheme ""`)
+	require.Empty(t, endpoint)
 }
 
 //nolint:thelper // Not a test helper function

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -84,3 +84,9 @@ type JWTSigner interface {
 	Sign(data []byte) ([]byte, error)
 	Headers() jose.Headers
 }
+
+// JSONWebKeySet represents a JWK Set object.
+// It uses the JWK type from aries-framework-go.
+type JSONWebKeySet struct {
+	JWKs []jwk.JWK `json:"keys"`
+}

--- a/pkg/oauth2/clientregistration.go
+++ b/pkg/oauth2/clientregistration.go
@@ -1,0 +1,93 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package oauth2 provides a client API for doing OAuth2 dynamic client registration per RFC7591:
+// https://datatracker.ietf.org/doc/html/rfc7591
+package oauth2
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// RegisterClient registers a new client at the given registration endpoint.
+// If the server requires an initial access token, then use the WithInitialAccessBearerToken option.
+func RegisterClient(registrationEndpoint string, clientMetadata *ClientMetadata,
+	opts ...Opt,
+) (*RegisterClientResponse, error) {
+	if registrationEndpoint == "" {
+		return nil, errors.New("registration endpoint cannot be blank")
+	}
+
+	// Technically, all fields are optional, so if the caller passes in nil then we will assume that they want to
+	// send an empty object to the server
+	if clientMetadata == nil {
+		clientMetadata = &ClientMetadata{}
+	}
+
+	processedOpts := processOpts(opts)
+
+	clientMetadataBytes, err := json.Marshal(clientMetadata)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := getRawResponse(clientMetadataBytes, registrationEndpoint, processedOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	var response *RegisterClientResponse
+
+	err = json.Unmarshal(respBody, &response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body into a RegisterClientResponse: %w", err)
+	}
+
+	return response, nil
+}
+
+func getRawResponse(requestBytes []byte, registrationEndpoint string, opts *opts) ([]byte, error) {
+	httpReq, err := http.NewRequest( //nolint: noctx // Timeout expected to be set in HTTP client already
+		http.MethodPost, registrationEndpoint, bytes.NewReader(requestBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	if opts.initialAccessBearerToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+opts.initialAccessBearerToken)
+	}
+
+	resp, err := opts.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		errClose := resp.Body.Close()
+		if errClose != nil {
+			println(fmt.Sprintf("failed to close response body: %s", errClose.Error()))
+		}
+	}()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("server returned status code %d with body [%s]", resp.StatusCode,
+			string(respBody))
+	}
+
+	return respBody, nil
+}

--- a/pkg/oauth2/clientregistration_test.go
+++ b/pkg/oauth2/clientregistration_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oauth2_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/wallet-sdk/pkg/oauth2"
+)
+
+type mockIssuerServerHandler struct {
+	t                             *testing.T
+	returnInternalServerErrorCode bool
+	writeEmptyBody                bool
+}
+
+func (m *mockIssuerServerHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	if m.returnInternalServerErrorCode {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+
+	if m.writeEmptyBody {
+		return
+	}
+
+	response := oauth2.RegisterClientResponse{
+		ClientID:       "Test",
+		ClientMetadata: &oauth2.ClientMetadata{ClientName: "ClientName"},
+	}
+
+	responseBytes, err := json.Marshal(response)
+	require.NoError(m.t, err)
+
+	_, err = w.Write(responseBytes)
+	require.NoError(m.t, err)
+}
+
+func TestRegisterClient(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		issuerServerHandler := &mockIssuerServerHandler{
+			t: t,
+		}
+
+		server := httptest.NewServer(issuerServerHandler)
+		defer server.Close()
+
+		opt := oauth2.WithHTTPClient(&http.Client{})
+
+		t.Run("Success - without initial access token", func(t *testing.T) {
+			response, err := oauth2.RegisterClient(server.URL, &oauth2.ClientMetadata{}, opt)
+			require.NoError(t, err)
+			require.NotEmpty(t, response)
+		})
+		t.Run("Success - with initial access token", func(t *testing.T) {
+			response, err := oauth2.RegisterClient(server.URL, &oauth2.ClientMetadata{},
+				oauth2.WithInitialAccessBearerToken("token"))
+			require.NoError(t, err)
+			require.NotEmpty(t, response)
+		})
+	})
+	t.Run("Blank registration endpoint", func(t *testing.T) {
+		response, err := oauth2.RegisterClient("", nil)
+		require.EqualError(t, err, "registration endpoint cannot be blank")
+		require.Nil(t, response)
+	})
+	t.Run("Server doesn't return 201 status code", func(t *testing.T) {
+		issuerServerHandler := &mockIssuerServerHandler{
+			t:                             t,
+			returnInternalServerErrorCode: true,
+		}
+
+		server := httptest.NewServer(issuerServerHandler)
+		defer server.Close()
+
+		response, err := oauth2.RegisterClient(server.URL, nil)
+		require.EqualError(t, err, "server returned status code 500 with body []")
+		require.Nil(t, response)
+	})
+	t.Run("Server returns empty body, resulting in a JSON unmarshal failure", func(t *testing.T) {
+		issuerServerHandler := &mockIssuerServerHandler{
+			t:              t,
+			writeEmptyBody: true,
+		}
+
+		server := httptest.NewServer(issuerServerHandler)
+		defer server.Close()
+
+		response, err := oauth2.RegisterClient(server.URL, nil)
+		require.EqualError(t, err, "failed to unmarshal response body into a RegisterClientResponse: "+
+			"unexpected end of JSON input")
+		require.Nil(t, response)
+	})
+	t.Run("Fail to create HTTP request", func(t *testing.T) {
+		response, err := oauth2.RegisterClient("%", nil)
+		require.EqualError(t, err, `parse "%": invalid URL escape "%"`)
+		require.Nil(t, response)
+	})
+}

--- a/pkg/oauth2/models.go
+++ b/pkg/oauth2/models.go
@@ -1,0 +1,39 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package oauth2
+
+import (
+	"github.com/trustbloc/wallet-sdk/pkg/api"
+)
+
+// ClientMetadata represents a set of client metadata values.
+type ClientMetadata struct {
+	RedirectURIs            []string           `json:"redirect_uris,omitempty"`
+	TokenEndpointAuthMethod string             `json:"token_endpoint_auth_method,omitempty"`
+	GrantTypes              []string           `json:"grant_types,omitempty"`
+	ResponseTypes           []string           `json:"response_types,omitempty"`
+	ClientName              string             `json:"client_name,omitempty"`
+	ClientURI               string             `json:"client_uri,omitempty"`
+	LogoURI                 string             `json:"logo_uri,omitempty"`
+	Scope                   string             `json:"scope,omitempty"`
+	Contacts                []string           `json:"contacts,omitempty"`
+	TOSURI                  string             `json:"tos_uri,omitempty"`
+	PolicyURI               string             `json:"policy_uri,omitempty"`
+	JWKSetURI               string             `json:"jwks_uri,omitempty"`
+	JWKSet                  *api.JSONWebKeySet `json:"jwks,omitempty"`
+	SoftwareID              string             `json:"software_id,omitempty"`
+	SoftwareVersion         string             `json:"software_version,omitempty"`
+}
+
+// RegisterClientResponse represents a response to a new client registration request.
+type RegisterClientResponse struct {
+	ClientID              string `json:"client_id"`
+	ClientSecret          string `json:"client_secret,omitempty"`
+	ClientIDIssuedAt      int    `json:"client_id_issued_at,omitempty"`
+	ClientSecretExpiresAt int    `json:"client_secret_expires_at,omitempty"`
+	*ClientMetadata
+}

--- a/pkg/oauth2/opts.go
+++ b/pkg/oauth2/opts.go
@@ -1,0 +1,52 @@
+package oauth2
+
+import (
+	"net/http"
+
+	"github.com/trustbloc/wallet-sdk/pkg/api"
+)
+
+type opts struct {
+	initialAccessBearerToken string
+	httpClient               *http.Client
+}
+
+// An Opt is a single option for a call to RegisterClient.
+type Opt func(opts *opts)
+
+// WithInitialAccessBearerToken is an option for a call to RegisterClient that allows a caller to specify an initial
+// access bearer token to use for the client registration request, which may be required by the server.
+func WithInitialAccessBearerToken(token string) Opt {
+	return func(opts *opts) {
+		opts.initialAccessBearerToken = token
+	}
+}
+
+// WithHTTPClient is an option for a call to RegisterClient that allows a caller to specify their own HTTP client.
+func WithHTTPClient(httpClient *http.Client) Opt {
+	return func(opts *opts) {
+		opts.httpClient = httpClient
+	}
+}
+
+func processOpts(options []Opt) *opts {
+	opts := mergeOpts(options)
+
+	if opts.httpClient == nil {
+		opts.httpClient = &http.Client{Timeout: api.DefaultHTTPTimeout}
+	}
+
+	return opts
+}
+
+func mergeOpts(options []Opt) *opts {
+	resolveOpts := &opts{}
+
+	for _, opt := range options {
+		if opt != nil {
+			opt(resolveOpts)
+		}
+	}
+
+	return resolveOpts
+}

--- a/pkg/openid4ci/models.go
+++ b/pkg/openid4ci/models.go
@@ -48,6 +48,7 @@ type OpenIDConfig struct {
 	AuthorizationEndpoint  string   `json:"authorization_endpoint,omitempty"`
 	ResponseTypesSupported []string `json:"response_types_supported,omitempty"`
 	TokenEndpoint          string   `json:"token_endpoint,omitempty"`
+	RegistrationEndpoint   *string  `json:"registration_endpoint,omitempty"`
 }
 
 // CredentialResponse is the object returned from the Client.Callback method.


### PR DESCRIPTION
Conforms to https://datatracker.ietf.org/doc/html/rfc7591.

Also added new methods on the Interaction object that a caller can use to determine whether an issuer support dynamic client registration (per https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).