### PR TITLE
fix(sdk)!: Fixed JWT params sent to issuer, added dynamic client reg test

### DIFF
--- a/cmd/wallet-sdk-gomobile/oauth2/clientmetadata.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientmetadata.go
@@ -204,3 +204,13 @@ func (c *ClientMetadata) SoftwareVersion() string {
 func (c *ClientMetadata) SetSoftwareVersion(softwareVersion string) {
 	c.goAPIClientMetadata.SoftwareVersion = softwareVersion
 }
+
+// IssuerState returns the issuer state.
+func (c *ClientMetadata) IssuerState() string {
+	return c.goAPIClientMetadata.IssuerState
+}
+
+// SetIssuerState sets the issuer state.
+func (c *ClientMetadata) SetIssuerState(issuerState string) {
+	c.goAPIClientMetadata.IssuerState = issuerState
+}

--- a/cmd/wallet-sdk-gomobile/oauth2/clientmetadata_test.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientmetadata_test.go
@@ -84,4 +84,7 @@ func TestClientMetadata(t *testing.T) {
 
 	clientMetadata.SetSoftwareVersion("SoftwareVersion")
 	require.Equal(t, "SoftwareVersion", clientMetadata.SoftwareVersion())
+
+	clientMetadata.SetIssuerState("IssuerState")
+	require.Equal(t, "IssuerState", clientMetadata.IssuerState())
 }

--- a/cmd/wallet-sdk-gomobile/oauth2/registerclientresponse.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/registerclientresponse.go
@@ -27,14 +27,39 @@ func (r *RegisterClientResponse) ClientSecret() string {
 	return r.goAPIRegisterClientResponse.ClientSecret
 }
 
+// HasClientIDIssuedAt indicates whether this RegisterClientResponse specifies when the client ID was issued.
+func (r *RegisterClientResponse) HasClientIDIssuedAt() bool {
+	return r.goAPIRegisterClientResponse.ClientIDIssuedAt != nil
+}
+
 // ClientIDIssuedAt returns the time at which the client ID was issued.
-func (r *RegisterClientResponse) ClientIDIssuedAt() int {
-	return r.goAPIRegisterClientResponse.ClientIDIssuedAt
+// The HasClientIDIssuedAt method should be called first to determine whether this RegisterClientResponse
+// specifies when the client ID was issued before calling this method.
+// This method returns an error if (and only if) HasClientIDIssuedAt returns false.
+func (r *RegisterClientResponse) ClientIDIssuedAt() (int, error) {
+	if !r.HasClientIDIssuedAt() {
+		return -1, errors.New("the register client response object does not specify when the client ID was issued")
+	}
+
+	return *r.goAPIRegisterClientResponse.ClientIDIssuedAt, nil
+}
+
+// HasClientSecretExpiresAt indicates whether this RegisterClientResponse specifies when the client secret expires.
+func (r *RegisterClientResponse) HasClientSecretExpiresAt() bool {
+	return r.goAPIRegisterClientResponse.ClientSecretExpiresAt != nil
 }
 
 // ClientSecretExpiresAt returns the time at which the client secret will expire or 0 if it will not expire.
-func (r *RegisterClientResponse) ClientSecretExpiresAt() int {
-	return r.goAPIRegisterClientResponse.ClientSecretExpiresAt
+// The HasClientSecretExpiresAt method should be called first to determine whether this RegisterClientResponse
+// specifies when the client secret will expire before calling this method.
+// This method returns an error if (and only if) HasClientSecretExpiresAt returns false.
+func (r *RegisterClientResponse) ClientSecretExpiresAt() (int, error) {
+	if !r.HasClientSecretExpiresAt() {
+		return -1, errors.New("the register client response object does not " +
+			"specify when the client secret expires")
+	}
+
+	return *r.goAPIRegisterClientResponse.ClientSecretExpiresAt, nil
 }
 
 // HasClientMetadata indicates whether this RegisterClientResponse has client metadata.
@@ -44,7 +69,7 @@ func (r *RegisterClientResponse) HasClientMetadata() bool {
 
 // ClientMetadata returns the ClientMetadata object. The HasClientMetadata method should be called first to
 // ensure this RegisterClientResponse object has any client metadata first before calling this method.
-// If this RegisterClientResponse has no client metadata, then this method returns an error.
+// This method returns an error if (and only if) HasClientMetadata returns false.
 func (r *RegisterClientResponse) ClientMetadata() (*ClientMetadata, error) {
 	if !r.HasClientMetadata() {
 		return nil, errors.New("the register client response object has no client metadata")

--- a/cmd/wallet-sdk-gomobile/openid4ci/grants.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/grants.go
@@ -1,6 +1,10 @@
 package openid4ci
 
-import openid4cigoapi "github.com/trustbloc/wallet-sdk/pkg/openid4ci"
+import (
+	"errors"
+
+	openid4cigoapi "github.com/trustbloc/wallet-sdk/pkg/openid4ci"
+)
 
 // PreAuthorizedCodeGrantParams represents an issuer's pre-authorized code grant parameters.
 type PreAuthorizedCodeGrantParams struct {
@@ -10,4 +14,25 @@ type PreAuthorizedCodeGrantParams struct {
 // PINRequired indicates whether the issuer requires a PIN.
 func (p *PreAuthorizedCodeGrantParams) PINRequired() bool {
 	return p.goAPIPreAuthorizedCodeGrantParams.PINRequired()
+}
+
+// AuthorizationCodeGrantParams represents an issuer's authorization code grant parameters.
+type AuthorizationCodeGrantParams struct {
+	goAPIAuthorizationCodeGrantParams *openid4cigoapi.AuthorizationCodeGrantParams
+}
+
+// HasIssuerState indicates whether this AuthorizationCodeGrantParams has an issuer state string.
+func (a *AuthorizationCodeGrantParams) HasIssuerState() bool {
+	return a.goAPIAuthorizationCodeGrantParams.IssuerState != nil
+}
+
+// IssuerState returns the issuer state string. The HasIssuerState method should be called first to
+// ensure this AuthorizationCodeGrantParams object has an issuer state string first before calling this method.
+// This method returns an error if (and only if) HasIssuerState returns false.
+func (a *AuthorizationCodeGrantParams) IssuerState() (string, error) {
+	if a.goAPIAuthorizationCodeGrantParams.IssuerState != nil {
+		return *a.goAPIAuthorizationCodeGrantParams.IssuerState, nil
+	}
+
+	return "", errors.New("authorization code grant params does not specify an issuer state")
 }

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
@@ -173,9 +173,8 @@ func (i *Interaction) PreAuthorizedCodeGrantTypeSupported() bool {
 
 // PreAuthorizedCodeGrantParams returns an object that can be used to determine an issuer's pre-authorized code grant
 // parameters. The caller should call the PreAuthorizedCodeGrantTypeSupported method first and only call this method to
-// get the params if PreAuthorizedCodeGrantTypeSupported returns true. This method only returns an error if
-// PreAuthorizedCodeGrantTypeSupported returns false, so the error return here can be safely ignored if
-// PreAuthorizedCodeGrantTypeSupported returns true.
+// get the params if PreAuthorizedCodeGrantTypeSupported returns true.
+// This method returns an error if (and only if) PreAuthorizedCodeGrantTypeSupported returns false.
 func (i *Interaction) PreAuthorizedCodeGrantParams() (*PreAuthorizedCodeGrantParams, error) {
 	goAPIPreAuthorizedCodeGrantParams, err := i.goAPIInteraction.PreAuthorizedCodeGrantParams()
 	if err != nil {
@@ -190,6 +189,21 @@ func (i *Interaction) PreAuthorizedCodeGrantParams() (*PreAuthorizedCodeGrantPar
 // AuthorizationCodeGrantTypeSupported indicates whether an issuer supports the authorization code grant type.
 func (i *Interaction) AuthorizationCodeGrantTypeSupported() bool {
 	return i.goAPIInteraction.AuthorizationCodeGrantTypeSupported()
+}
+
+// AuthorizationCodeGrantParams returns an object that can be used to determine the issuer's authorization code grant
+// parameters. The caller should call the AuthorizationCodeGrantTypeSupported method first and only call this method to
+// get the params if AuthorizationCodeGrantTypeSupported returns true.
+// This method returns an error if (and only if) AuthorizationCodeGrantTypeSupported returns false.
+func (i *Interaction) AuthorizationCodeGrantParams() (*AuthorizationCodeGrantParams, error) {
+	goAPIAuthorizationCodeGrantParams, err := i.goAPIInteraction.AuthorizationCodeGrantParams()
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthorizationCodeGrantParams{
+		goAPIAuthorizationCodeGrantParams: goAPIAuthorizationCodeGrantParams,
+	}, nil
 }
 
 // DynamicClientRegistrationSupported indicates whether the issuer supports dynamic client registration.

--- a/cmd/wallet-sdk-gomobile/openid4ci/testdata/sample_credential_offer.json
+++ b/cmd/wallet-sdk-gomobile/openid4ci/testdata/sample_credential_offer.json
@@ -1,0 +1,18 @@
+{
+  "credential_issuer":"example.com",
+  "credentials":[
+    {
+      "format":"jwt_vc_json",
+      "types":[
+        "VerifiableCredential",
+        "VerifiedEmployee"
+      ]
+    }
+  ],
+  "grants":{
+    "urn:ietf:params:oauth:grant-type:pre-authorized_code":{
+      "pre-authorized_code":"8e557518-bbb1-4483-9490-d80f4f54f3361677012959367644351",
+      "user_pin_required":true
+    }
+  }
+}

--- a/pkg/oauth2/models.go
+++ b/pkg/oauth2/models.go
@@ -27,13 +27,14 @@ type ClientMetadata struct {
 	JWKSet                  *api.JSONWebKeySet `json:"jwks,omitempty"`
 	SoftwareID              string             `json:"software_id,omitempty"`
 	SoftwareVersion         string             `json:"software_version,omitempty"`
+	IssuerState             string             `json:"issuer_state,omitempty"`
 }
 
 // RegisterClientResponse represents a response to a new client registration request.
 type RegisterClientResponse struct {
 	ClientID              string `json:"client_id"`
 	ClientSecret          string `json:"client_secret,omitempty"`
-	ClientIDIssuedAt      int    `json:"client_id_issued_at,omitempty"`
-	ClientSecretExpiresAt int    `json:"client_secret_expires_at,omitempty"`
+	ClientIDIssuedAt      *int   `json:"client_id_issued_at,omitempty"`
+	ClientSecretExpiresAt *int   `json:"client_secret_expires_at,omitempty"`
 	*ClientMetadata
 }

--- a/pkg/openid4ci/grants.go
+++ b/pkg/openid4ci/grants.go
@@ -19,13 +19,14 @@ func (p *PreAuthorizedCodeGrantParams) PINRequired() bool {
 	return p.userPINRequired
 }
 
-type authorizationCodeGrantParams struct {
-	issuerState *string
+// AuthorizationCodeGrantParams represents an issuer's authorization code grant parameters.
+type AuthorizationCodeGrantParams struct {
+	IssuerState *string
 }
 
 func determineIssuerGrantCapabilities(
 	credentialOffer *CredentialOffer,
-) (*PreAuthorizedCodeGrantParams, *authorizationCodeGrantParams, error) {
+) (*PreAuthorizedCodeGrantParams, *AuthorizationCodeGrantParams, error) {
 	rawPreAuthorizedCodeGrantParams, preAuthorizedCodeGrantExists := credentialOffer.Grants[preAuthorizedGrantType]
 	rawAuthorizationCodeGrantParams, authorizationCodeGrantExists := credentialOffer.Grants[authorizationCodeGrantType]
 
@@ -35,7 +36,7 @@ func determineIssuerGrantCapabilities(
 
 	var preAuthorizedCodeGrantParams *PreAuthorizedCodeGrantParams
 
-	var authorizationCodeGrantParams *authorizationCodeGrantParams
+	var authorizationCodeGrantParams *AuthorizationCodeGrantParams
 
 	var err error
 	if preAuthorizedCodeGrantExists {
@@ -83,7 +84,7 @@ func processPreAuthorizedCodeGrantParams(rawParams map[string]interface{}) (*Pre
 	return &PreAuthorizedCodeGrantParams{preAuthorizedCode: preAuthorizedCode, userPINRequired: userPINRequired}, nil
 }
 
-func processAuthorizationCodeGrantParams(rawParams map[string]interface{}) (*authorizationCodeGrantParams, error) {
+func processAuthorizationCodeGrantParams(rawParams map[string]interface{}) (*AuthorizationCodeGrantParams, error) {
 	var issuerState *string
 
 	issuerStateUntyped, exists := rawParams["issuer_state"]
@@ -96,5 +97,5 @@ func processAuthorizationCodeGrantParams(rawParams map[string]interface{}) (*aut
 		issuerState = &issuerStateAsString
 	}
 
-	return &authorizationCodeGrantParams{issuerState: issuerState}, nil
+	return &AuthorizationCodeGrantParams{IssuerState: issuerState}, nil
 }

--- a/pkg/openid4ci/models.go
+++ b/pkg/openid4ci/models.go
@@ -22,13 +22,6 @@ type Credentials struct {
 	Types  []string `json:"types,omitempty"`
 }
 
-// RawGrant represents the grant types that the credential issuer is prepared to process for the given credential offer.
-type RawGrant struct {
-	PreAuthorizedCode string `json:"pre-authorized_code,omitempty"`
-	UserPINRequired   bool   `json:"user_pin_required,omitempty"`
-	IssuerState       string `json:"issuer_state,omitempty"`
-}
-
 // AuthorizeResult is the object returned from the Client.Authorize method.
 // An empty/missing AuthorizationRedirectEndpoint indicates that the wallet is pre-authorized.
 type AuthorizeResult struct {

--- a/pkg/openid4ci/openid4ci_test.go
+++ b/pkg/openid4ci/openid4ci_test.go
@@ -1024,6 +1024,21 @@ func TestInteraction_GrantTypes(t *testing.T) {
 	require.True(t, preAuthorizedCodeGrantParams.PINRequired())
 
 	require.False(t, interaction.AuthorizationCodeGrantTypeSupported())
+
+	authorizationCodeGrantParams, err := interaction.AuthorizationCodeGrantParams()
+	require.EqualError(t, err, "issuer does not support the authorization code grant")
+	require.Nil(t, authorizationCodeGrantParams)
+
+	interaction = newInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", true))
+
+	require.True(t, interaction.AuthorizationCodeGrantTypeSupported())
+
+	authorizationCodeGrantParams, err = interaction.AuthorizationCodeGrantParams()
+	require.NoError(t, err)
+	require.NotNil(t, authorizationCodeGrantParams)
+
+	require.NotNil(t, authorizationCodeGrantParams.IssuerState)
+	require.Equal(t, "1234", *authorizationCodeGrantParams.IssuerState)
 }
 
 func TestInteraction_DynamicClientRegistration(t *testing.T) {

--- a/test/integration/fixtures/.env
+++ b/test/integration/fixtures/.env
@@ -5,7 +5,7 @@
 #
 
 VC_REST_IMAGE=ghcr.io/trustbloc-cicd/vc-server
-VC_REST_IMAGE_TAG=v1.0.1-snapshot-8edb1ba
+VC_REST_IMAGE_TAG=v1.0.1-snapshot-16924cd
 
 
 # Remote JSON-LD context provider

--- a/test/integration/fixtures/docker-compose.yml
+++ b/test/integration/fixtures/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - VC_TRANSIENT_DATA_STORE_TYPE=redis
       - VC_REDIS_URL=redis.example.com:6379
       - VC_REDIS_DISABLE_TLS=true
+      - TEMP_DISABLE_ISS_AUD_TYP_IAT_CHECK=true
     ports:
       - "8075:8075"
       - "48127:48127"

--- a/test/integration/fixtures/krakend-config/settings/endpoint.json
+++ b/test/integration/fixtures/krakend-config/settings/endpoint.json
@@ -104,6 +104,14 @@
       ]
     },
     {
+      "endpoint": "/oidc/register",
+      "method": "POST",
+      "input_headers": [
+        "Authorization",
+        "Content-Type"
+      ]
+    },
+    {
       "endpoint": "/verifier/profiles/{profileID}/{profileVersion}/credentials/verify",
       "method": "POST",
       "protected": true,

--- a/test/integration/fixtures/oauth-clients/clients.json
+++ b/test/integration/fixtures/oauth-clients/clients.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "oidc4vc_client",
+    "client_id": "oidc4vc_client",
     "redirect_uris": ["http://127.0.0.1/callback"],
     "grant_types": ["authorization_code"],
-    "response_types": ["code","token"],
+    "response_types": ["code"],
     "scopes": ["openid","profile"],
-    "public": true
+    "token_endpoint_auth_method": "none"
   }
 ]

--- a/test/integration/fixtures/profile/profiles.json
+++ b/test/integration/fixtures/profile/profiles.json
@@ -24,13 +24,23 @@
           }
         },
         "oidcConfig": {
-          "client_id": "bank_issuer",
-          "client_secret_handle": "bank-issuer-secret",
-          "scope": [
+          "client_id": "7d4u50e7w6nfq8tfayhzplgjf",
+          "client_secret_handle": "282ks4fkuqfosus5k0x30abnv",
+          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration",
+          "scopes_supported": [
             "openid",
             "profile"
           ],
-          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration"
+          "grant_types_supported": [
+            "authorization_code"
+          ],
+          "response_types_supported": [
+            "code"
+          ],
+          "token_endpoint_auth_methods_supported": [
+            "none"
+          ],
+          "pre-authorized_grant_anonymous_access_supported": true
         },
         "credentialTemplates": [
           {
@@ -184,13 +194,23 @@
           }
         },
         "oidcConfig": {
-          "client_id": "drivers_license_issuer",
-          "client_secret_handle": "drivers-license-issuer-secret",
-          "scope": [
+          "client_id": "7d4u50e7w6nfq8tfayhzplgjf",
+          "client_secret_handle": "282ks4fkuqfosus5k0x30abnv",
+          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration",
+          "scopes_supported": [
             "openid",
             "profile"
           ],
-          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration"
+          "grant_types_supported": [
+            "authorization_code"
+          ],
+          "response_types_supported": [
+            "code"
+          ],
+          "token_endpoint_auth_methods_supported": [
+            "none"
+          ],
+          "pre-authorized_grant_anonymous_access_supported": true
         },
         "credentialTemplates": [
           {
@@ -376,11 +396,22 @@
         "oidcConfig": {
           "client_id": "7d4u50e7w6nfq8tfayhzplgjf",
           "client_secret_handle": "282ks4fkuqfosus5k0x30abnv",
-          "scope": [
+          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration",
+          "scopes_supported": [
             "openid",
             "profile"
           ],
-          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration"
+          "grant_types_supported": [
+            "authorization_code"
+          ],
+          "response_types_supported": [
+            "code"
+          ],
+          "token_endpoint_auth_methods_supported": [
+            "none"
+          ],
+          "enable_dynamic_client_registration": true,
+          "pre-authorized_grant_anonymous_access_supported": true
         },
         "credentialTemplates": [
           {
@@ -535,13 +566,23 @@
           }
         },
         "oidcConfig": {
-          "client_id": "university_degree_issuer",
-          "client_secret_handle": "university_degree_issuer-secret",
-          "scope": [
+          "client_id": "7d4u50e7w6nfq8tfayhzplgjf",
+          "client_secret_handle": "282ks4fkuqfosus5k0x30abnv",
+          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration",
+          "scopes_supported": [
             "openid",
             "profile"
           ],
-          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration"
+          "grant_types_supported": [
+            "authorization_code"
+          ],
+          "response_types_supported": [
+            "code"
+          ],
+          "token_endpoint_auth_methods_supported": [
+            "none"
+          ],
+          "pre-authorized_grant_anonymous_access_supported": true
         },
         "credentialTemplates": [
           {
@@ -636,7 +677,6 @@
       },
       "createDID": true
     },
-
     {
       "issuer": {
         "id": "university_degree_issuer_bbs",
@@ -657,13 +697,23 @@
           }
         },
         "oidcConfig": {
-          "client_id": "university_degree_issuer_bbs",
-          "client_secret_handle": "university_degree_issuer_bbs-secret",
-          "scope": [
+          "client_id": "7d4u50e7w6nfq8tfayhzplgjf",
+          "client_secret_handle": "282ks4fkuqfosus5k0x30abnv",
+          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration",
+          "scopes_supported": [
             "openid",
             "profile"
           ],
-          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration"
+          "grant_types_supported": [
+            "authorization_code"
+          ],
+          "response_types_supported": [
+            "code"
+          ],
+          "token_endpoint_auth_methods_supported": [
+            "none"
+          ],
+          "pre-authorized_grant_anonymous_access_supported": true
         },
         "credentialTemplates": [
           {
@@ -778,13 +828,23 @@
           }
         },
         "oidcConfig": {
-          "client_id": "bank_issuer",
-          "client_secret_handle": "bank-issuer-secret",
-          "scope": [
+          "client_id": "7d4u50e7w6nfq8tfayhzplgjf",
+          "client_secret_handle": "282ks4fkuqfosus5k0x30abnv",
+          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration",
+          "scopes_supported": [
             "openid",
             "profile"
           ],
-          "issuer_well_known": "http://cognito-mock.trustbloc.local:9229/local_5a9GzRvB/.well-known/openid-configuration"
+          "grant_types_supported": [
+            "authorization_code"
+          ],
+          "response_types_supported": [
+            "code"
+          ],
+          "token_endpoint_auth_methods_supported": [
+            "none"
+          ],
+          "pre-authorized_grant_anonymous_access_supported": true
         },
         "credentialTemplates": [
           {


### PR DESCRIPTION
Breaking API change: Updated the dynamic client registration response model to avoid potential confusion between absent values and zero values.

Other changes:

* Made fixes/updated to the JWT claims and header that are sent to the issuer to ensure compliance with the OpenID4CI spec.
* Added an integration test for dynamic client registration. Note that a flag was set for the vc-server instance used in the integration temporarily due to a bug with the "aud" and "iat" claim checks. This flag will be removed once the bug has been fixed and the vc-server version here updated.
* Added methods to the interaction object which will allow a user to get the issuer_state value, and also added the ability to set an issuer_state value in the client metadata object sent to the dynamic client registration endpoint.