### PR TITLE
fix(sdk): Enable state-checking and remove vc-server flag

### DIFF
--- a/pkg/openid4ci/errors.go
+++ b/pkg/openid4ci/errors.go
@@ -9,20 +9,21 @@ package openid4ci
 // Constants' names and reasons are obvious so they do not require additional comments.
 // nolint:golint,nolintlint
 const (
-	module                                 = "OCI"
-	NoClientConfigProvidedError            = "NO_CLIENT_CONFIG_PROVIDED"
-	ClientConfigNoDIDResolverProvidedError = "CLIENT_CONFIG_NO_DID_RESOLVER_PROVIDED"
-	InvalidIssuanceURIError                = "INVALID_ISSUANCE_URI"
-	InvalidCredentialOfferError            = "INVALID_CREDENTIAL_OFFER" //nolint:gosec //false positive
-	UnsupportedCredentialTypeInOfferError  = "UNSUPPORTED_CREDENTIAL_TYPE_IN_OFFER"
-	PINRequiredError                       = "PIN_REQUIRED"
-	IssuerOpenIDConfigFetchFailedError     = "ISSUER_OPENID_FETCH_FAILED"
-	MetadataFetchFailedError               = "METADATA_FETCH_FAILED"
-	TokenFetchFailedError                  = "TOKEN_FETCH_FAILED" //nolint:gosec //false positive
-	JWTSigningFailedError                  = "JWT_SIGNING_FAILED"
-	CredentialFetchFailedError             = "CREDENTIAL_FETCH_FAILED" //nolint:gosec //false positive
-	KeyIDNotContainDIDPartError            = "KEY_ID_NOT_CONTAIN_DID_PART"
-	CredentialParseError                   = "CREDENTIAL_PARSE_FAILED" //nolint:gosec //false positive
+	module                                    = "OCI"
+	NoClientConfigProvidedError               = "NO_CLIENT_CONFIG_PROVIDED"
+	ClientConfigNoDIDResolverProvidedError    = "CLIENT_CONFIG_NO_DID_RESOLVER_PROVIDED"
+	InvalidIssuanceURIError                   = "INVALID_ISSUANCE_URI"
+	InvalidCredentialOfferError               = "INVALID_CREDENTIAL_OFFER" //nolint:gosec //false positive
+	UnsupportedCredentialTypeInOfferError     = "UNSUPPORTED_CREDENTIAL_TYPE_IN_OFFER"
+	PINRequiredError                          = "PIN_REQUIRED"
+	IssuerOpenIDConfigFetchFailedError        = "ISSUER_OPENID_FETCH_FAILED"
+	MetadataFetchFailedError                  = "METADATA_FETCH_FAILED"
+	TokenFetchFailedError                     = "TOKEN_FETCH_FAILED" //nolint:gosec //false positive
+	JWTSigningFailedError                     = "JWT_SIGNING_FAILED"
+	CredentialFetchFailedError                = "CREDENTIAL_FETCH_FAILED" //nolint:gosec //false positive
+	KeyIDNotContainDIDPartError               = "KEY_ID_NOT_CONTAIN_DID_PART"
+	CredentialParseError                      = "CREDENTIAL_PARSE_FAILED"                     //nolint:gosec,lll //false positive, can't shorten
+	StateInRedirectURINotMatchingAuthURLError = "STATE_IN_REDIRECT_URI_NOT_MATCHING_AUTH_URL" //nolint:gosec,lll //false positive, can't shorten
 )
 
 // Constants' names and reasons are obvious so they do not require additional comments.
@@ -41,4 +42,5 @@ const (
 	CredentialFetchFailedCode
 	KeyIDNotContainDIDPartCode
 	CredentialParseFailedCode
+	StateInRedirectURINotMatchingAuthURLCode
 )

--- a/pkg/openid4ci/openid4ci.go
+++ b/pkg/openid4ci/openid4ci.go
@@ -308,11 +308,14 @@ func (i *Interaction) requestAccessToken(redirectURIWithAuthCode string) error {
 		return errors.New("redirect URI is missing a state value")
 	}
 
-	// TODO: Enable state checking
-	// state := parsedURI.Query().Get("state")
-	// if state != i.authCodeURLState {
-	//	return errors.New("state in redirect URI does not match the state from the authorization URL")
-	// }
+	state := parsedURI.Query().Get("state")
+	if state != i.authCodeURLState {
+		return walleterror.NewExecutionError(
+			module,
+			StateInRedirectURINotMatchingAuthURLCode,
+			StateInRedirectURINotMatchingAuthURLError,
+			errors.New("state in redirect URI does not match the state from the authorization URL"))
+	}
 
 	i.openIDConfig, err = i.getOpenIDConfig()
 	if err != nil {

--- a/test/integration/fixtures/.env
+++ b/test/integration/fixtures/.env
@@ -5,7 +5,7 @@
 #
 
 VC_REST_IMAGE=ghcr.io/trustbloc-cicd/vc-server
-VC_REST_IMAGE_TAG=v1.0.1-snapshot-16924cd
+VC_REST_IMAGE_TAG=v1.0.1-snapshot-c938ec4
 
 
 # Remote JSON-LD context provider

--- a/test/integration/fixtures/docker-compose.yml
+++ b/test/integration/fixtures/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       - VC_TRANSIENT_DATA_STORE_TYPE=redis
       - VC_REDIS_URL=redis.example.com:6379
       - VC_REDIS_DISABLE_TLS=true
-      - TEMP_DISABLE_ISS_AUD_TYP_IAT_CHECK=true
     ports:
       - "8075:8075"
       - "48127:48127"
@@ -155,7 +154,6 @@ services:
   api-gateway.trustbloc.local:
     container_name: api-gateway.trustbloc.local
     image: devopsfaith/krakend:${KRAKEND_IMAGE_TAG}
-    platform: linux/amd64
     ports:
       - "5566:8080"
     command: run -d -c /etc/krakend/krakend.tmpl


### PR DESCRIPTION
With recent fixes to VCS (vc-server), state-checking during the OpenID4CI authorization-code flow now work. Also, the JWT claims sent to the credential endpoint are now validated correctly, so the temporary flag we used during the integration tests is no longer needed.