### PR TITLE
docs(sdk): Update README.md for the wallet-sdk-gomobile

### DIFF
--- a/cmd/wallet-sdk-gomobile/README.md
+++ b/cmd/wallet-sdk-gomobile/README.md
@@ -6,11 +6,9 @@ This package contains the `gomobile`-compatible version of the SDK. It acts as a
 
 * [Go 1.20](https://go.dev/doc/install) or newer
 * The gomobile tools:
-  ```
-  go install golang.org/x/mobile/cmd/gomobile@latest
-  export PATH="$PATH:$HOME/go/bin"
-  gomobile init
-  ```
+  * `go install golang.org/x/mobile/cmd/gomobile@latest`
+  * `$GOPATH/bin` added to your path
+  * ``gomobile init``
 ### Android Bindings
 
 * Android SDK (installable via the SDK Manager in [Android Studio](https://developer.android.com/studio/install))

--- a/cmd/wallet-sdk-gomobile/README.md
+++ b/cmd/wallet-sdk-gomobile/README.md
@@ -8,10 +8,9 @@ This package contains the `gomobile`-compatible version of the SDK. It acts as a
 * The gomobile tools:
   ```
   go install golang.org/x/mobile/cmd/gomobile@latest
+  export PATH="$PATH:$HOME/go/bin"
   gomobile init
   ```
-* `$GOPATH/bin` added to your path
-
 ### Android Bindings
 
 * Android SDK (installable via the SDK Manager in [Android Studio](https://developer.android.com/studio/install))


### PR DESCRIPTION
During the installation of `go`, I was stuck a bit because `gomobile` didn't worked.
[This issue](https://github.com/golang/go/issues/16935) helped me. 

I think it's worth modifying the README.