### PR TITLE
feat(sdk)!: Improvements to dynamic client registration API

### DIFF
--- a/cmd/wallet-sdk-gomobile/oauth2/clientmetadata.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientmetadata.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package oauth2
 
 import (
+	"strings"
+
 	"github.com/hyperledger/aries-framework-go/component/kmscrypto/doc/jose/jwk"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	goapi "github.com/trustbloc/wallet-sdk/pkg/api"
@@ -105,14 +107,41 @@ func (c *ClientMetadata) SetLogoURI(logoURI string) {
 	c.goAPIClientMetadata.LogoURI = logoURI
 }
 
-// Scope returns the scope.
-func (c *ClientMetadata) Scope() string {
-	return c.goAPIClientMetadata.Scope
+// Scopes returns the scopes.
+func (c *ClientMetadata) Scopes() *api.StringArray {
+	scopesStrings := strings.Split(c.goAPIClientMetadata.Scope, " ")
+
+	if len(scopesStrings) == 1 && scopesStrings[0] == "" {
+		return nil
+	}
+
+	scopes := &api.StringArray{Strings: scopesStrings}
+
+	return scopes
 }
 
-// SetScope sets the scope types.
-func (c *ClientMetadata) SetScope(scope string) {
-	c.goAPIClientMetadata.Scope = scope
+// SetScopes sets the scope values.
+func (c *ClientMetadata) SetScopes(scopes *api.StringArray) {
+	if scopes == nil || scopes.Length() == 0 {
+		c.goAPIClientMetadata.Scope = ""
+
+		return
+	}
+
+	var sb strings.Builder
+
+	numOfScopes := scopes.Length()
+
+	indexOfLastScope := numOfScopes - 1
+
+	for i := 0; i < indexOfLastScope; i++ {
+		sb.WriteString(scopes.AtIndex(i))
+		sb.WriteString(" ")
+	}
+
+	sb.WriteString(scopes.AtIndex(indexOfLastScope))
+
+	c.goAPIClientMetadata.Scope = sb.String()
 }
 
 // Contacts returns the contacts.

--- a/cmd/wallet-sdk-gomobile/oauth2/clientmetadata_test.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientmetadata_test.go
@@ -55,8 +55,24 @@ func TestClientMetadata(t *testing.T) {
 	clientMetadata.SetLogoURI("LogoURI")
 	require.Equal(t, "LogoURI", clientMetadata.LogoURI())
 
-	clientMetadata.SetScope("Scope")
-	require.Equal(t, "Scope", clientMetadata.Scope())
+	scopes := &api.StringArray{Strings: []string{"scope1", "scope2"}}
+	clientMetadata.SetScopes(scopes)
+	require.Equal(t, 2, clientMetadata.Scopes().Length())
+	require.Equal(t, "scope1", clientMetadata.Scopes().AtIndex(0))
+	require.Equal(t, "scope2", clientMetadata.Scopes().AtIndex(1))
+
+	scopes = &api.StringArray{Strings: []string{"onlyOneScope"}}
+	clientMetadata.SetScopes(scopes)
+	require.Equal(t, 1, clientMetadata.Scopes().Length())
+	require.Equal(t, "onlyOneScope", clientMetadata.Scopes().AtIndex(0))
+
+	// Try setting with an empty array
+	clientMetadata.SetScopes(api.NewStringArray())
+	require.Nil(t, clientMetadata.Scopes())
+
+	// Try setting with a nil array
+	clientMetadata.SetScopes(nil)
+	require.Nil(t, clientMetadata.Scopes())
 
 	clientMetadata.SetContacts(nil)
 	require.Equal(t, 0, clientMetadata.Contacts().Length())

--- a/cmd/wallet-sdk-gomobile/oauth2/clientregistration_test.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/clientregistration_test.go
@@ -40,7 +40,7 @@ func (m *mockIssuerServerHandler) ServeHTTP(w http.ResponseWriter, _ *http.Reque
 			ClientSecret:          "ClientSecret",
 			ClientIDIssuedAt:      &testIssuedAtAndExpiresAtValue,
 			ClientSecretExpiresAt: &testIssuedAtAndExpiresAtValue,
-			ClientMetadata: &goapioauth2.ClientMetadata{
+			RegisteredMetadata: goapioauth2.RegisteredMetadata{
 				RedirectURIs:            []string{"RedirectURI1"},
 				TokenEndpointAuthMethod: "TokenEndpointAuthMethod",
 				GrantTypes:              []string{"GrantType1"},
@@ -48,7 +48,7 @@ func (m *mockIssuerServerHandler) ServeHTTP(w http.ResponseWriter, _ *http.Reque
 				ClientName:              "ClientName",
 				ClientURI:               "ClientURI",
 				LogoURI:                 "LogoURI",
-				Scope:                   "Scope",
+				Scope:                   "scope1 scope2",
 				Contacts:                []string{"Contact1"},
 				TOSURI:                  "TOSURI",
 				PolicyURI:               "PolicyURI",
@@ -105,9 +105,7 @@ func TestRegisterClient(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 10, clientSecretExpiresAt)
 
-			require.True(t, response.HasClientMetadata())
-			clientMetadata, err := response.ClientMetadata()
-			require.NoError(t, err)
+			clientMetadata := response.RegisteredMetadata()
 
 			require.Equal(t, 1, clientMetadata.RedirectURIs().Length())
 			require.Equal(t, "RedirectURI1", clientMetadata.RedirectURIs().AtIndex(0))
@@ -119,7 +117,9 @@ func TestRegisterClient(t *testing.T) {
 			require.Equal(t, "ClientName", clientMetadata.ClientName())
 			require.Equal(t, "ClientURI", clientMetadata.ClientURI())
 			require.Equal(t, "LogoURI", clientMetadata.LogoURI())
-			require.Equal(t, "Scope", clientMetadata.Scope())
+			require.Equal(t, 2, clientMetadata.Scopes().Length())
+			require.Equal(t, "scope1", clientMetadata.Scopes().AtIndex(0))
+			require.Equal(t, "scope2", clientMetadata.Scopes().AtIndex(1))
 			require.Equal(t, 1, clientMetadata.Contacts().Length())
 			require.Equal(t, "Contact1", clientMetadata.Contacts().AtIndex(0))
 			require.Equal(t, "TOSURI", clientMetadata.TOSURI())

--- a/cmd/wallet-sdk-gomobile/oauth2/registerclientresponse.go
+++ b/cmd/wallet-sdk-gomobile/oauth2/registerclientresponse.go
@@ -8,7 +8,9 @@ package oauth2
 
 import (
 	"errors"
+	"strings"
 
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 	goapioauth2 "github.com/trustbloc/wallet-sdk/pkg/oauth2"
 )
 
@@ -62,18 +64,106 @@ func (r *RegisterClientResponse) ClientSecretExpiresAt() (int, error) {
 	return *r.goAPIRegisterClientResponse.ClientSecretExpiresAt, nil
 }
 
-// HasClientMetadata indicates whether this RegisterClientResponse has client metadata.
-func (r *RegisterClientResponse) HasClientMetadata() bool {
-	return r.goAPIRegisterClientResponse.ClientMetadata != nil
+// RegisteredMetadata returns the RegisteredMetadata object, which can be used to determine what metadata was
+// actually registered by the authorization server (which may differ from the client metadata in the request).
+func (r *RegisterClientResponse) RegisteredMetadata() *RegisteredMetadata {
+	return &RegisteredMetadata{goAPIRegisteredMetadata: r.goAPIRegisterClientResponse.RegisteredMetadata}
 }
 
-// ClientMetadata returns the ClientMetadata object. The HasClientMetadata method should be called first to
-// ensure this RegisterClientResponse object has any client metadata first before calling this method.
-// This method returns an error if (and only if) HasClientMetadata returns false.
-func (r *RegisterClientResponse) ClientMetadata() (*ClientMetadata, error) {
-	if !r.HasClientMetadata() {
-		return nil, errors.New("the register client response object has no client metadata")
+// RegisteredMetadata represents a set of registered metadata values.
+type RegisteredMetadata struct {
+	goAPIRegisteredMetadata goapioauth2.RegisteredMetadata
+}
+
+// RedirectURIs returns the redirect URIs.
+func (c *RegisteredMetadata) RedirectURIs() *api.StringArray {
+	return &api.StringArray{Strings: c.goAPIRegisteredMetadata.RedirectURIs}
+}
+
+// TokenEndpointAuthMethod returns the token endpoint authentication method.
+func (c *RegisteredMetadata) TokenEndpointAuthMethod() string {
+	return c.goAPIRegisteredMetadata.TokenEndpointAuthMethod
+}
+
+// GrantTypes returns the grant types.
+func (c *RegisteredMetadata) GrantTypes() *api.StringArray {
+	return &api.StringArray{Strings: c.goAPIRegisteredMetadata.GrantTypes}
+}
+
+// ResponseTypes returns the response types.
+func (c *RegisteredMetadata) ResponseTypes() *api.StringArray {
+	return &api.StringArray{Strings: c.goAPIRegisteredMetadata.ResponseTypes}
+}
+
+// ClientName returns the client name.
+func (c *RegisteredMetadata) ClientName() string {
+	return c.goAPIRegisteredMetadata.ClientName
+}
+
+// ClientURI returns the client URI.
+func (c *RegisteredMetadata) ClientURI() string {
+	return c.goAPIRegisteredMetadata.ClientURI
+}
+
+// LogoURI returns the logo URI.
+func (c *RegisteredMetadata) LogoURI() string {
+	return c.goAPIRegisteredMetadata.LogoURI
+}
+
+// Scopes returns the scopes.
+func (c *RegisteredMetadata) Scopes() *api.StringArray {
+	scopesStrings := strings.Split(c.goAPIRegisteredMetadata.Scope, " ")
+
+	if len(scopesStrings) == 1 && scopesStrings[0] == "" {
+		return nil
 	}
 
-	return &ClientMetadata{goAPIClientMetadata: r.goAPIRegisterClientResponse.ClientMetadata}, nil
+	scopes := &api.StringArray{Strings: scopesStrings}
+
+	return scopes
+}
+
+// Contacts returns the contacts.
+func (c *RegisteredMetadata) Contacts() *api.StringArray {
+	return &api.StringArray{Strings: c.goAPIRegisteredMetadata.Contacts}
+}
+
+// TOSURI returns the TOS (terms of service) document URI.
+func (c *RegisteredMetadata) TOSURI() string {
+	return c.goAPIRegisteredMetadata.TOSURI
+}
+
+// PolicyURI returns the privacy policy document URI.
+func (c *RegisteredMetadata) PolicyURI() string {
+	return c.goAPIRegisteredMetadata.PolicyURI
+}
+
+// JWKSetURI returns the JWK Set document URI.
+func (c *RegisteredMetadata) JWKSetURI() string {
+	return c.goAPIRegisteredMetadata.JWKSetURI
+}
+
+// JWKSet returns the JWK Set document value. If the client metadata doesn't have one, then nil is returned instead.
+func (c *RegisteredMetadata) JWKSet() *api.JSONWebKeySet {
+	if c.goAPIRegisteredMetadata.JWKSet == nil {
+		return nil
+	}
+
+	jsonWebKeySet := api.JSONWebKeySet{JWKs: make([]api.JSONWebKey, len(c.goAPIRegisteredMetadata.JWKSet.JWKs))}
+
+	for i := range c.goAPIRegisteredMetadata.JWKSet.JWKs {
+		jsonWebKeySet.JWKs[i] = api.JSONWebKey{JWK: &c.goAPIRegisteredMetadata.JWKSet.JWKs[i]}
+	}
+
+	return &jsonWebKeySet
+}
+
+// SoftwareID returns the software ID.
+func (c *RegisteredMetadata) SoftwareID() string {
+	return c.goAPIRegisteredMetadata.SoftwareID
+}
+
+// SoftwareVersion returns the software version.
+func (c *RegisteredMetadata) SoftwareVersion() string {
+	return c.goAPIRegisteredMetadata.SoftwareVersion
 }

--- a/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
@@ -308,7 +308,10 @@ class MainActivity : FlutterActivity() {
                 var dynamicRegistrationSupported =  openID4CI.dynamicRegistrationSupported()
                 var clientID = authCodeArgs["clientID"].toString()
                 val redirectURI = authCodeArgs["redirectURI"].toString()
-                var scopes = authCodeArgs["scopes"] as ArrayList<String>
+                var scopesFromArgs = authCodeArgs["scopes"] as ArrayList<String>
+
+                var scopes = StringArray()
+                for (scope in scopesFromArgs) scopes.append(scope)
 
                 if (dynamicRegistrationSupported)  {
                     var dynamicRegistrationEndpoint = openID4CI.dynamicRegistrationEndpoint()
@@ -322,8 +325,7 @@ class MainActivity : FlutterActivity() {
                     redirectUri.append(redirectURI)
                     clientMetadata.setRedirectURIs(redirectUri)
 
-                    var spaceSeparatedScopes = scopes.joinToString(" ")
-                    clientMetadata.setScope(spaceSeparatedScopes)
+                    clientMetadata.setScopes(scopes)
 
                     clientMetadata.setTokenEndpointAuthMethod("none")
 
@@ -335,9 +337,13 @@ class MainActivity : FlutterActivity() {
 
                     var registrationResp = Oauth2.registerClient(dynamicRegistrationEndpoint, clientMetadata, null)
                     clientID = registrationResp.clientID()
+
+                    // Use the actual scopes registered by the authorization server,
+                    // which may differ from the scopes we specified in the metadata in our request.
+                    scopes = registrationResp.registeredMetadata().scopes()
                 }
 
-                if (!authCodeArgs.keys.contains("scopes")) {
+                if (scopes.length() == 0.toLong()) {
                     authorizationLink = openID4CI.createAuthorizationURL(
                         clientID,
                         redirectURI)

--- a/demo/app/android/app/src/main/kotlin/walletsdk/openid4ci/OpenID4CI.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/openid4ci/OpenID4CI.kt
@@ -40,16 +40,12 @@ class OpenID4CI constructor(
         return ""
     }
 
-    fun createAuthorizationURLWithScopes(scopes:ArrayList<String>, clientID: String, redirectURI: String): String {
+    fun createAuthorizationURLWithScopes(scopes: StringArray, clientID: String, redirectURI: String): String {
         if (!newInteraction.authorizationCodeGrantTypeSupported()) {
             return "Not implemented"
         }
-        val scopesArr = StringArray();
-        for (scope in scopes) {
-            scopesArr.append(scope);
-        }
 
-        val opts = CreateAuthorizationURLOpts().setScopes(scopesArr)
+        val opts = CreateAuthorizationURLOpts().setScopes(scopes)
 
         return newInteraction.createAuthorizationURL(
             clientID,

--- a/demo/app/ios/Runner/OpenID4CI.swift
+++ b/demo/app/ios/Runner/OpenID4CI.swift
@@ -41,15 +41,10 @@ public class OpenID4CI {
         return ""
     }
     
-    func createAuthorizationURLWithScopes(scopes: [String], clientID: String, redirectURI: String) throws  -> String {
-     let scopesArr = ApiStringArray()
-        for scope in scopes {
-            scopesArr!.append(scope)!
-        }
-
-      var error: NSError?
+    func createAuthorizationURLWithScopes(scopes: ApiStringArray, clientID: String, redirectURI: String) throws  -> String {
+     var error: NSError?
         
-      let opts = Openid4ciNewCreateAuthorizationURLOpts()!.setScopes(scopesArr)
+      let opts = Openid4ciNewCreateAuthorizationURLOpts()!.setScopes(scopes)
     
        let authorizationLink =  initiatedInteraction.createAuthorizationURL(clientID, redirectURI: redirectURI, opts: opts, error: &error)
         if let actualError = error {

--- a/pkg/oauth2/clientregistration_test.go
+++ b/pkg/oauth2/clientregistration_test.go
@@ -37,8 +37,8 @@ func (m *mockIssuerServerHandler) ServeHTTP(w http.ResponseWriter, _ *http.Reque
 	}
 
 	response := oauth2.RegisterClientResponse{
-		ClientID:       "Test",
-		ClientMetadata: &oauth2.ClientMetadata{ClientName: "ClientName"},
+		ClientID:           "Test",
+		RegisteredMetadata: oauth2.RegisteredMetadata{ClientName: "ClientName"},
 	}
 
 	responseBytes, err := json.Marshal(response)

--- a/pkg/oauth2/models.go
+++ b/pkg/oauth2/models.go
@@ -19,7 +19,7 @@ type ClientMetadata struct {
 	ClientName              string             `json:"client_name,omitempty"`
 	ClientURI               string             `json:"client_uri,omitempty"`
 	LogoURI                 string             `json:"logo_uri,omitempty"`
-	Scope                   string             `json:"scope,omitempty"`
+	Scope                   string             `json:"scope,omitempty"` // Space-separated strings
 	Contacts                []string           `json:"contacts,omitempty"`
 	TOSURI                  string             `json:"tos_uri,omitempty"`
 	PolicyURI               string             `json:"policy_uri,omitempty"`
@@ -27,8 +27,13 @@ type ClientMetadata struct {
 	JWKSet                  *api.JSONWebKeySet `json:"jwks,omitempty"`
 	SoftwareID              string             `json:"software_id,omitempty"`
 	SoftwareVersion         string             `json:"software_version,omitempty"`
-	IssuerState             string             `json:"issuer_state,omitempty"`
+	// TODO: This is a temporary workaround for VCS. To be removed.
+	IssuerState string `json:"issuer_state,omitempty"`
 }
+
+// RegisteredMetadata specifies what metadata was actually registered by the authorization server (which may differ
+// from the client metadata in the request).
+type RegisteredMetadata ClientMetadata
 
 // RegisterClientResponse represents a response to a new client registration request.
 type RegisterClientResponse struct {
@@ -36,5 +41,5 @@ type RegisterClientResponse struct {
 	ClientSecret          string `json:"client_secret,omitempty"`
 	ClientIDIssuedAt      *int   `json:"client_id_issued_at,omitempty"`
 	ClientSecretExpiresAt *int   `json:"client_secret_expires_at,omitempty"`
-	*ClientMetadata
+	RegisteredMetadata
 }


### PR DESCRIPTION
Breaking change: Changes to names and methods in dynamic client registration API. See below for details.

* In the Gomobile API, changed the scopes parameter type to a StringArray. Internally, it will be converted to the space-separated string that is required by the dynamic client registration spec, so this way the user of the SDK doesn't have to deal with splitting/parse spaces. Also, changed the method names from `scope` to `scopes`.
* In the Gomobile API, removed the hasClientMetadata method from the response object. Response objects don't actually have a nested clientMetadata object - the ClientMetadata object is just an abstraction here to make code cleaner and allow for reuse - so it doesn't make sense to ask if the object exists or not.
* For the response object, switched it from having a ClientMetadata object to a RegisteredMetadata object. While the objects fields are the same, the context and meaning of them is different, which justifies having different names.