### PR TITLE
feat(sdk): Option to set issuer state when creating authorization URL

### DIFF
--- a/cmd/wallet-sdk-gomobile/openid4ci/createauthorizationurlopts.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/createauthorizationurlopts.go
@@ -11,7 +11,8 @@ import "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 // CreateAuthorizationURLOpts contains all optional arguments that can be passed into the
 // createAuthorizationURL method.
 type CreateAuthorizationURLOpts struct {
-	scopes *api.StringArray
+	scopes      *api.StringArray
+	issuerState *string
 }
 
 // NewCreateAuthorizationURLOpts returns a new CreateAuthorizationURLOpts object.
@@ -23,6 +24,28 @@ func NewCreateAuthorizationURLOpts() *CreateAuthorizationURLOpts {
 // requires scopes to be set, then this option must be used.
 func (c *CreateAuthorizationURLOpts) SetScopes(scopes *api.StringArray) *CreateAuthorizationURLOpts {
 	c.scopes = scopes
+
+	return c
+}
+
+// SetIssuerState is an option for the createAuthorizationURL method that specifies an issuer state to be included in
+// the authorization URL.
+//
+// For an issuer-instantiated flow, this option should not be required in most cases. Typically, if an issuer requires
+// this parameter, it will be included in the original credential offer, and in such cases the createAuthorizationURL
+// method will automatically include it in the authorization URL without requiring this option to be used.
+// Since the spec leaves open the possibility that the issuer_state parameter can come from some other place,
+// this option exists to allow for compatibility with such scenarios. However, the spec also states that if the
+// credential offer specifies an issuer state, then it MUST be used in the authorization URL. Thus, in order to prevent
+// potential confusion, if the credential offer already has an issuer state value, but a caller still uses this option,
+// then an error will be returned by the CreateAuthorizationURL method. If needed, a caller can check the IssuerState
+// field in the AuthorizationCodeGrantParams object.
+//
+// For a wallet-instantiated flow, an issuer state may be required by some issuers. There is no credential offer
+// in a wallet-instantiated flow, so if an issuer state is required then it must always be explicitly provided using
+// this option.
+func (c *CreateAuthorizationURLOpts) SetIssuerState(issuerState string) *CreateAuthorizationURLOpts {
+	c.issuerState = &issuerState
 
 	return c
 }

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction.go
@@ -97,8 +97,13 @@ func (i *IssuerInitiatedInteraction) CreateAuthorizationURL(clientID, redirectUR
 		opts.scopes = api.NewStringArray()
 	}
 
-	return i.goAPIInteraction.CreateAuthorizationURL(clientID, redirectURI,
-		openid4cigoapi.WithScopes(opts.scopes.Strings))
+	goAPIOpts := []openid4cigoapi.CreateAuthorizationURLOpt{openid4cigoapi.WithScopes(opts.scopes.Strings)}
+
+	if opts.issuerState != nil {
+		goAPIOpts = append(goAPIOpts, openid4cigoapi.WithIssuerState(*opts.issuerState))
+	}
+
+	return i.goAPIInteraction.CreateAuthorizationURL(clientID, redirectURI, goAPIOpts...)
 }
 
 // RequestCredentialWithPreAuth requests credential(s) from the issuer. This method can only be used for the

--- a/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction.go
@@ -124,8 +124,14 @@ func (i *WalletInitiatedInteraction) CreateAuthorizationURL(clientID, redirectUR
 		credentialTypes = api.NewStringArray()
 	}
 
+	goAPIOpts := []openid4cigoapi.CreateAuthorizationURLOpt{openid4cigoapi.WithScopes(opts.scopes.Strings)}
+
+	if opts.issuerState != nil {
+		goAPIOpts = append(goAPIOpts, openid4cigoapi.WithIssuerState(*opts.issuerState))
+	}
+
 	authorizationURL, err := i.goAPIInteraction.CreateAuthorizationURL(clientID, redirectURI, credentialFormat,
-		credentialTypes.Strings, openid4cigoapi.WithScopes(opts.scopes.Strings))
+		credentialTypes.Strings, goAPIOpts...)
 	if err != nil {
 		return "", wrapper.ToMobileErrorWithTrace(err, i.oTel)
 	}

--- a/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction_test.go
@@ -81,8 +81,10 @@ func TestWalletInitiatedInteraction_Flow(t *testing.T) {
 
 	credentialTypes := api.NewStringArray().Append("type")
 
+	createAuthorizationURLOpts := openid4ci.NewCreateAuthorizationURLOpts().SetIssuerState("IssuerState")
+
 	authURL, err := interaction.CreateAuthorizationURL("client", "redirectURI",
-		"format", credentialTypes, nil)
+		"format", credentialTypes, createAuthorizationURLOpts)
 	require.NoError(t, err)
 	require.NotEmpty(t, authURL)
 

--- a/pkg/openid4ci/createauthorizationurlopts.go
+++ b/pkg/openid4ci/createauthorizationurlopts.go
@@ -7,16 +7,39 @@ SPDX-License-Identifier: Apache-2.0
 package openid4ci
 
 type createAuthorizationURLOpts struct {
-	scopes []string
+	scopes      []string
+	issuerState *string
 }
 
-// CreateAuthorizationURLOpt is an option for the createAuthorizationURL method.
+// CreateAuthorizationURLOpt is an option for the CreateAuthorizationURL method.
 type CreateAuthorizationURLOpt func(opts *createAuthorizationURLOpts)
 
 // WithScopes is an option for the createAuthorizationURL method that allows scopes to be passed in.
 func WithScopes(scopes []string) CreateAuthorizationURLOpt {
 	return func(opts *createAuthorizationURLOpts) {
 		opts.scopes = scopes
+	}
+}
+
+// WithIssuerState is an option for the CreateAuthorizationURL method that specifies an issuer state to be included in
+// the authorization URL.
+//
+// For an issuer-instantiated flow, this option should not be required in most cases. Typically, if an issuer requires
+// this parameter, it will be included in the original credential offer, and in such cases the createAuthorizationURL
+// method will automatically include it in the authorization URL without requiring this option to be used.
+// Since the spec leaves open the possibility that the issuer_state parameter can come from some other place,
+// this option exists to allow for compatibility with such scenarios. However, the spec also states that if the
+// credential offer specifies an issuer state, then it MUST be used in the authorization URL. Thus, in order to prevent
+// potential confusion, if the credential offer already has an issuer state value, but a caller still uses this option,
+// then an error will be returned by the CreateAuthorizationURL method. If needed, a caller can check the IssuerState
+// field in the AuthorizationCodeGrantParams object.
+//
+// For a wallet-instantiated flow, an issuer state may be required by some issuers. There is no credential offer
+// in a wallet-instantiated flow, so if an issuer state is required then it must always be explicitly provided using
+// this option.
+func WithIssuerState(issuerState string) CreateAuthorizationURLOpt {
+	return func(opts *createAuthorizationURLOpts) {
+		opts.issuerState = &issuerState
 	}
 }
 

--- a/pkg/openid4ci/interaction.go
+++ b/pkg/openid4ci/interaction.go
@@ -59,13 +59,11 @@ type interaction struct {
 // Check the issuer's capabilities first using the Capabilities method.
 // If scopes are needed, pass them in using the WithScopes option.
 func (i *interaction) createAuthorizationURL(clientID, redirectURI, format string, types []string, issuerState *string,
-	opts ...CreateAuthorizationURLOpt,
+	scopes []string,
 ) (string, error) {
-	processedOpts := processCreateAuthorizationURLOpts(opts)
-
-	var err error
-
 	if i.issuerMetadata == nil {
+		var err error
+
 		i.issuerMetadata, err = metadatafetcher.Get(i.issuerURI, i.httpClient, i.metricsLogger,
 			"Authorization")
 		if err != nil {
@@ -77,9 +75,9 @@ func (i *interaction) createAuthorizationURL(clientID, redirectURI, format strin
 		}
 	}
 
-	i.instantiateOAuth2Config(clientID, redirectURI, processedOpts.scopes)
+	i.instantiateOAuth2Config(clientID, redirectURI, scopes)
 
-	err = i.instantiateCodeVerifier()
+	err := i.instantiateCodeVerifier()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/openid4ci/issuerinitiatedinteraction_test.go
+++ b/pkg/openid4ci/issuerinitiatedinteraction_test.go
@@ -153,10 +153,10 @@ func (f *failingMetricsLogger) Log(metricsEvent *api.MetricsEvent) error {
 func TestNewInteraction(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		t.Run("Credential format is jwt_vc_json", func(t *testing.T) {
-			newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", false))
+			newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", false, true))
 		})
 		t.Run("Credential format is jwt_vc_json-ld", func(t *testing.T) {
-			credentialOffer := createSampleCredentialOffer(t, true)
+			credentialOffer := createSampleCredentialOffer(t, true, true)
 
 			credentialOffer.Credentials[0].Format = "jwt_vc_json-ld"
 
@@ -255,7 +255,7 @@ func TestNewInteraction(t *testing.T) {
 		require.Nil(t, interaction)
 	})
 	t.Run("Unsupported credential type", func(t *testing.T) {
-		credentialOffer := createSampleCredentialOffer(t, false)
+		credentialOffer := createSampleCredentialOffer(t, false, true)
 
 		credentialOffer.Credentials[0].Format = "UnsupportedType"
 
@@ -281,7 +281,7 @@ func TestNewInteraction(t *testing.T) {
 		server := httptest.NewServer(issuerServerHandler)
 		defer server.Close()
 
-		issuerServerHandler.credentialOffer = createCredentialOffer(t, server.URL, false)
+		issuerServerHandler.credentialOffer = createCredentialOffer(t, server.URL, false, true)
 
 		issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
 			server.URL)
@@ -354,7 +354,7 @@ func TestIssuerInitiatedInteraction_CreateAuthorizationURL(t *testing.T) {
 			`"authorization_server":"%s"}`,
 			server.URL, authorizationServerURL)
 
-		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 		authorizationURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
 		require.NoError(t, err)
@@ -364,7 +364,7 @@ func TestIssuerInitiatedInteraction_CreateAuthorizationURL(t *testing.T) {
 			"format%22%3A%22jwt_vc_json%22%7D&client_id=clientID")
 	})
 	t.Run("Fail to get issuer metadata", func(t *testing.T) {
-		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", true))
+		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", true, true))
 
 		authorizationURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
 		require.EqualError(t, err, "METADATA_FETCH_FAILED(OCI1-0004):failed to get issuer metadata: openid "+
@@ -392,7 +392,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
 					server.URL)
 
-				interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, false))
+				interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, false, true))
 
 				credentials, err := interaction.RequestCredentialWithPreAuth(&jwtSignerMock{
 					keyID: mockKeyID,
@@ -414,7 +414,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 					TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
 				}
 
-				issuerServerHandler.credentialOffer = createCredentialOffer(t, server.URL, false)
+				issuerServerHandler.credentialOffer = createCredentialOffer(t, server.URL, false, true)
 
 				issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
 					server.URL)
@@ -454,7 +454,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			config := getTestClientConfig(t)
 
 			interaction, err := openid4ci.NewIssuerInitiatedInteraction(
-				createCredentialOfferIssuanceURI(t, "example.com", false), config)
+				createCredentialOfferIssuanceURI(t, "example.com", false, true), config)
 			require.NoError(t, err)
 
 			credentials, err := interaction.RequestCredentialWithPreAuth(&jwtSignerMock{
@@ -465,7 +465,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			require.Nil(t, credentials)
 		})
 		t.Run("Fail to fetch issuer's OpenID configuration", func(t *testing.T) {
-			requestURI := createCredentialOfferIssuanceURI(t, "BadURL", false)
+			requestURI := createCredentialOfferIssuanceURI(t, "BadURL", false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -484,7 +484,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			}
 			server := httptest.NewServer(issuerServerHandler)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -505,7 +505,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
 			}
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -529,7 +529,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
 			}
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -553,7 +553,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
 			}
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -577,7 +577,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
 			}
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -601,7 +601,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
 			}
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -622,7 +622,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
 			}
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -645,7 +645,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -670,7 +670,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -696,7 +696,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -722,7 +722,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -748,7 +748,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -774,7 +774,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -800,7 +800,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -823,7 +823,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -845,7 +845,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = `{"credential_endpoint":"http://BadURL"}`
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -864,7 +864,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
 			}
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -885,7 +885,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -914,7 +914,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -936,7 +936,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`, server.URL)
 
-			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+			requestURI := createCredentialOfferIssuanceURI(t, server.URL, false, true)
 
 			localKMS, err := localkms.NewLocalKMS(localkms.Config{Storage: localkms.NewMemKMSStore()})
 			require.NoError(t, err)
@@ -977,7 +977,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			config.MetricsLogger = &failingMetricsLogger{attemptFailNumber: 1}
 
 			interaction, err := openid4ci.NewIssuerInitiatedInteraction(
-				createCredentialOfferIssuanceURI(t, server.URL, false), config)
+				createCredentialOfferIssuanceURI(t, server.URL, false, true), config)
 			require.NoError(t, err)
 
 			credentials, err := interaction.RequestCredentialWithPreAuth(&jwtSignerMock{
@@ -1004,7 +1004,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			config.MetricsLogger = &failingMetricsLogger{attemptFailNumber: 2}
 
 			interaction, err := openid4ci.NewIssuerInitiatedInteraction(
-				createCredentialOfferIssuanceURI(t, server.URL, false), config)
+				createCredentialOfferIssuanceURI(t, server.URL, false, true), config)
 			require.NoError(t, err)
 
 			credentials, err := interaction.RequestCredentialWithPreAuth(&jwtSignerMock{
@@ -1030,7 +1030,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			config.MetricsLogger = &failingMetricsLogger{attemptFailNumber: 3}
 
 			interaction, err := openid4ci.NewIssuerInitiatedInteraction(
-				createCredentialOfferIssuanceURI(t, server.URL, false), config)
+				createCredentialOfferIssuanceURI(t, server.URL, false, true), config)
 			require.NoError(t, err)
 
 			credentials, err := interaction.RequestCredentialWithPreAuth(&jwtSignerMock{
@@ -1061,7 +1061,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			config.MetricsLogger = &failingMetricsLogger{attemptFailNumber: 4}
 
 			interaction, err := openid4ci.NewIssuerInitiatedInteraction(
-				createCredentialOfferIssuanceURI(t, server.URL, false), config)
+				createCredentialOfferIssuanceURI(t, server.URL, false, true), config)
 			require.NoError(t, err)
 
 			credentials, err := interaction.RequestCredentialWithPreAuth(&jwtSignerMock{
@@ -1075,38 +1075,104 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 	})
 	t.Run("Auth flow", func(t *testing.T) {
 		t.Run("Success", func(t *testing.T) {
-			issuerServerHandler := &mockIssuerServerHandler{
-				t:                  t,
-				credentialResponse: sampleCredentialResponse,
-			}
+			t.Run("Issuer state specified in credential offer", func(t *testing.T) {
+				issuerServerHandler := &mockIssuerServerHandler{
+					t:                  t,
+					credentialResponse: sampleCredentialResponse,
+				}
 
-			server := httptest.NewServer(issuerServerHandler)
-			defer server.Close()
+				server := httptest.NewServer(issuerServerHandler)
+				defer server.Close()
 
-			issuerServerHandler.openIDConfig = &openid4ci.OpenIDConfig{
-				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
-			}
+				issuerServerHandler.openIDConfig = &openid4ci.OpenIDConfig{
+					TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
+				}
 
-			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
-				server.URL)
+				issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
+					server.URL)
 
-			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+				interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
-			// Needed to create the OAuth2 config object.
-			authURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
-			require.NoError(t, err)
+				// Needed to create the OAuth2 config object.
+				authURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
+				require.NoError(t, err)
 
-			redirectURIWithParams := "redirectURI?code=1234&state=" + getStateFromAuthURL(t, authURL)
+				redirectURIWithParams := "redirectURI?code=1234&state=" + getStateFromAuthURL(t, authURL)
 
-			credentials, err := interaction.RequestCredentialWithAuth(&jwtSignerMock{
-				keyID: mockKeyID,
-			}, redirectURIWithParams)
-			require.NoError(t, err)
-			require.Len(t, credentials, 1)
-			require.NotEmpty(t, credentials[0])
+				credentials, err := interaction.RequestCredentialWithAuth(&jwtSignerMock{
+					keyID: mockKeyID,
+				}, redirectURIWithParams)
+				require.NoError(t, err)
+				require.Len(t, credentials, 1)
+				require.NotEmpty(t, credentials[0])
+			})
+			t.Run("Issuer state not specified in credential offer", func(t *testing.T) {
+				issuerServerHandler := &mockIssuerServerHandler{
+					t:                  t,
+					credentialResponse: sampleCredentialResponse,
+				}
+
+				server := httptest.NewServer(issuerServerHandler)
+				defer server.Close()
+
+				issuerServerHandler.openIDConfig = &openid4ci.OpenIDConfig{
+					TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
+				}
+
+				issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
+					server.URL)
+
+				interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, false))
+
+				// Needed to create the OAuth2 config object.
+				authURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
+				require.NoError(t, err)
+
+				redirectURIWithParams := "redirectURI?code=1234&state=" + getStateFromAuthURL(t, authURL)
+
+				credentials, err := interaction.RequestCredentialWithAuth(&jwtSignerMock{
+					keyID: mockKeyID,
+				}, redirectURIWithParams)
+				require.NoError(t, err)
+				require.Len(t, credentials, 1)
+				require.NotEmpty(t, credentials[0])
+			})
+			t.Run("Issuer state not specified in credential offer, but is specified by caller in "+
+				"CreateAuthorizationURL call", func(t *testing.T) {
+				issuerServerHandler := &mockIssuerServerHandler{
+					t:                  t,
+					credentialResponse: sampleCredentialResponse,
+				}
+
+				server := httptest.NewServer(issuerServerHandler)
+				defer server.Close()
+
+				issuerServerHandler.openIDConfig = &openid4ci.OpenIDConfig{
+					TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
+				}
+
+				issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
+					server.URL)
+
+				interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, false))
+
+				// Needed to create the OAuth2 config object.
+				authURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI",
+					openid4ci.WithIssuerState("IssuerState"))
+				require.NoError(t, err)
+
+				redirectURIWithParams := "redirectURI?code=1234&state=" + getStateFromAuthURL(t, authURL)
+
+				credentials, err := interaction.RequestCredentialWithAuth(&jwtSignerMock{
+					keyID: mockKeyID,
+				}, redirectURIWithParams)
+				require.NoError(t, err)
+				require.Len(t, credentials, 1)
+				require.NotEmpty(t, credentials[0])
+			})
 		})
 		t.Run("Authorization URL not created first", func(t *testing.T) {
-			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", true))
+			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", true, true))
 
 			credentials, err := interaction.RequestCredentialWithAuth(&jwtSignerMock{
 				keyID: mockKeyID,
@@ -1133,7 +1199,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				`"authorization_server":"%s"}`,
 				server.URL, authorizationServerURL)
 
-			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 			_, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
 			require.NoError(t, err)
@@ -1163,7 +1229,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				`"authorization_server":"%s"}`,
 				server.URL, authorizationServerURL)
 
-			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 			_, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
 			require.NoError(t, err)
@@ -1193,7 +1259,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				`"authorization_server":"%s"}`,
 				server.URL, authorizationServerURL)
 
-			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 			_, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
 			require.NoError(t, err)
@@ -1221,7 +1287,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
 				server.URL)
 
-			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 			// Needed to create the OAuth2 config object.
 			authURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
@@ -1253,7 +1319,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
 				server.URL)
 
-			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 			// Needed to create the OAuth2 config object.
 			authURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
@@ -1269,37 +1335,6 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 				"response: JWT_SIGNING_FAILED(OCI1-0005):failed to create JWT: sign token failed: create "+
 				"JWS: sign JWS: sign JWS verification data: test failure")
 			require.Nil(t, credentials)
-		})
-		t.Run("Success", func(t *testing.T) {
-			issuerServerHandler := &mockIssuerServerHandler{
-				t:                  t,
-				credentialResponse: sampleCredentialResponse,
-			}
-
-			server := httptest.NewServer(issuerServerHandler)
-			defer server.Close()
-
-			issuerServerHandler.openIDConfig = &openid4ci.OpenIDConfig{
-				TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
-			}
-
-			issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
-				server.URL)
-
-			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
-
-			// Needed to create the OAuth2 config object.
-			authURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
-			require.NoError(t, err)
-
-			redirectURIWithParams := "redirectURI?code=1234&state=" + getStateFromAuthURL(t, authURL)
-
-			credentials, err := interaction.RequestCredentialWithAuth(&jwtSignerMock{
-				keyID: mockKeyID,
-			}, redirectURIWithParams)
-			require.NoError(t, err)
-			require.Len(t, credentials, 1)
-			require.NotEmpty(t, credentials[0])
 		})
 	})
 	t.Run("State in redirect URI does not match the state from the auth URL", func(t *testing.T) {
@@ -1317,7 +1352,7 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 		issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
 			server.URL)
 
-		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 		// Needed to create the OAuth2 config object.
 		_, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
@@ -1332,10 +1367,34 @@ func TestIssuerInitiatedInteraction_RequestCredential(t *testing.T) {
 			"redirect URI does not match the state from the authorization URL")
 		require.Nil(t, credentials)
 	})
+	t.Run("Conflicting issuer state", func(t *testing.T) {
+		issuerServerHandler := &mockIssuerServerHandler{
+			t: t,
+		}
+
+		server := httptest.NewServer(issuerServerHandler)
+		defer server.Close()
+
+		issuerServerHandler.openIDConfig = &openid4ci.OpenIDConfig{
+			TokenEndpoint: fmt.Sprintf("%s/oidc/token", server.URL),
+		}
+
+		issuerServerHandler.issuerMetadata = fmt.Sprintf(`{"credential_endpoint":"%s/credential"}`,
+			server.URL)
+
+		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
+
+		authorizationURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI",
+			openid4ci.WithIssuerState("SomeOtherState"))
+		require.EqualError(t, err, "INVALID_SDK_USAGE(OCI3-0000):the credential offer already specifies "+
+			"an issuer state, and a conflicting issuer state value was provided. An issuer state should only be "+
+			"provided if required by the issuer and the credential offer does not specify one already")
+		require.Empty(t, authorizationURL)
+	})
 }
 
 func TestIssuerInitiatedInteraction_GrantTypes(t *testing.T) {
-	interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", false))
+	interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", false, true))
 
 	require.True(t, interaction.PreAuthorizedCodeGrantTypeSupported())
 
@@ -1352,7 +1411,7 @@ func TestIssuerInitiatedInteraction_GrantTypes(t *testing.T) {
 		"INVALID_SDK_USAGE(OCI3-0000):issuer does not support the authorization code grant")
 	require.Nil(t, authorizationCodeGrantParams)
 
-	interaction = newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", true))
+	interaction = newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", true, true))
 
 	require.True(t, interaction.AuthorizationCodeGrantTypeSupported())
 
@@ -1366,7 +1425,7 @@ func TestIssuerInitiatedInteraction_GrantTypes(t *testing.T) {
 
 func TestIssuerInitiatedInteraction_DynamicClientRegistration(t *testing.T) {
 	t.Run("Fail to get OpenID configuration", func(t *testing.T) {
-		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", false))
+		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", false, true))
 
 		supported, err := interaction.DynamicClientRegistrationSupported()
 		require.EqualError(t, err, "ISSUER_OPENID_CONFIG_FETCH_FAILED(OCI1-0003):failed to fetch issuer's "+
@@ -1390,7 +1449,7 @@ func TestIssuerInitiatedInteraction_DynamicClientRegistration(t *testing.T) {
 
 		issuerServerHandler.openIDConfig = &openid4ci.OpenIDConfig{}
 
-		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 		supported, err := interaction.DynamicClientRegistrationSupported()
 		require.NoError(t, err)
@@ -1413,7 +1472,7 @@ func TestIssuerInitiatedInteraction_DynamicClientRegistration(t *testing.T) {
 
 		issuerServerHandler.openIDConfig = &openid4ci.OpenIDConfig{RegistrationEndpoint: &testEndpoint}
 
-		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true))
+		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
 		supported, err := interaction.DynamicClientRegistrationSupported()
 		require.NoError(t, err)
@@ -1427,7 +1486,7 @@ func TestIssuerInitiatedInteraction_DynamicClientRegistration(t *testing.T) {
 
 func TestIssuerInitiatedInteraction_Issuer_URI(t *testing.T) {
 	testIssuerURI := "https://example.com"
-	requestURI := createCredentialOfferIssuanceURI(t, testIssuerURI, false)
+	requestURI := createCredentialOfferIssuanceURI(t, testIssuerURI, false, true)
 
 	interaction := newIssuerInitiatedInteraction(t, requestURI)
 
@@ -1518,10 +1577,13 @@ func (s *jwtSignerMock) Headers() jose.Headers {
 	}
 }
 
-func createCredentialOfferIssuanceURI(t *testing.T, issuerURL string, includeAuthCodeGrant bool) string {
+// includeIssuerStateParam only applies if includeAuthCodeGrant is true.
+func createCredentialOfferIssuanceURI(t *testing.T, issuerURL string, includeAuthCodeGrant,
+	includeIssuerStateParam bool,
+) string {
 	t.Helper()
 
-	credentialOffer := createCredentialOffer(t, issuerURL, includeAuthCodeGrant)
+	credentialOffer := createCredentialOffer(t, issuerURL, includeAuthCodeGrant, includeIssuerStateParam)
 
 	credentialOfferBytes, err := json.Marshal(credentialOffer)
 	require.NoError(t, err)
@@ -1531,17 +1593,21 @@ func createCredentialOfferIssuanceURI(t *testing.T, issuerURL string, includeAut
 	return "openid-vc://?credential_offer=" + credentialOfferEscaped
 }
 
-func createCredentialOffer(t *testing.T, issuerURL string, includeAuthCodeGrant bool) *openid4ci.CredentialOffer {
+func createCredentialOffer(t *testing.T, issuerURL string, includeAuthCodeGrant,
+	includeIssuerStateParam bool,
+) *openid4ci.CredentialOffer {
 	t.Helper()
 
-	credentialOffer := createSampleCredentialOffer(t, includeAuthCodeGrant)
+	credentialOffer := createSampleCredentialOffer(t, includeAuthCodeGrant, includeIssuerStateParam)
 
 	credentialOffer.CredentialIssuer = issuerURL
 
 	return credentialOffer
 }
 
-func createSampleCredentialOffer(t *testing.T, includeAuthCodeGrant bool) *openid4ci.CredentialOffer {
+func createSampleCredentialOffer(t *testing.T, includeAuthCodeGrant,
+	includeIssuerStateParam bool,
+) *openid4ci.CredentialOffer {
 	t.Helper()
 
 	var credentialOffer openid4ci.CredentialOffer
@@ -1550,7 +1616,13 @@ func createSampleCredentialOffer(t *testing.T, includeAuthCodeGrant bool) *openi
 	require.NoError(t, err)
 
 	if includeAuthCodeGrant {
-		credentialOffer.Grants["authorization_code"] = map[string]interface{}{"issuer_state": "1234"}
+		authCodeGrant := map[string]interface{}{}
+
+		if includeIssuerStateParam {
+			authCodeGrant["issuer_state"] = "1234"
+		}
+
+		credentialOffer.Grants["authorization_code"] = authCodeGrant
 	}
 
 	return &credentialOffer

--- a/pkg/openid4ci/walletinitiatedinteraction.go
+++ b/pkg/openid4ci/walletinitiatedinteraction.go
@@ -102,7 +102,18 @@ func (i *WalletInitiatedInteraction) SupportedCredentials() ([]SupportedCredenti
 func (i *WalletInitiatedInteraction) CreateAuthorizationURL(clientID, redirectURI, credentialFormat string,
 	credentialTypes []string, opts ...CreateAuthorizationURLOpt,
 ) (string, error) {
-	return i.interaction.createAuthorizationURL(clientID, redirectURI, credentialFormat, credentialTypes, nil, opts...)
+	processedOpts := processCreateAuthorizationURLOpts(opts)
+
+	authorizationURL, err := i.interaction.createAuthorizationURL(clientID, redirectURI, credentialFormat,
+		credentialTypes, processedOpts.issuerState, processedOpts.scopes)
+	if err != nil {
+		return "", err
+	}
+
+	i.credentialFormat = credentialFormat
+	i.credentialTypes = credentialTypes
+
+	return authorizationURL, nil
 }
 
 // RequestCredential requests credential(s) from the issuer. This method is the final step in the

--- a/pkg/openid4ci/walletinitiatedinteraction_test.go
+++ b/pkg/openid4ci/walletinitiatedinteraction_test.go
@@ -54,7 +54,7 @@ func TestWalletInitiatedInteraction(t *testing.T) {
 
 	// Needed to create the OAuth2 config object.
 	authURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI",
-		"jwt_vc_json", types)
+		"jwt_vc_json", types, openid4ci.WithIssuerState("issuerState"))
 	require.NoError(t, err)
 
 	redirectURIWithParams := "redirectURI?code=1234&state=" + getStateFromAuthURL(t, authURL)


### PR DESCRIPTION
* Added an option to set the issuer state value when creating an authorization URL during the OpenID4CI flow.
* Fixed a bug where the credential type and formats were not being set in the credential request sent to the issuer during the wallet-initiated OpenID4CI flow.