### PR TITLE
feat(sdk): Merge higher-level errors into mobile error details field

### DIFF
--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
@@ -387,8 +387,8 @@ func TestIssuerInitiatedInteraction_GrantTypes(t *testing.T) {
 	require.False(t, interaction.AuthorizationCodeGrantTypeSupported())
 
 	authorizationCodeGrantParams, err := interaction.AuthorizationCodeGrantParams()
-	requireErrorContains(t, err,
-		"INVALID_SDK_USAGE(OCI3-0000):issuer does not support the authorization code grant")
+	requireErrorContains(t, err, "INVALID_SDK_USAGE")
+	requireErrorContains(t, err, "issuer does not support the authorization code grant")
 	require.Nil(t, authorizationCodeGrantParams)
 
 	interaction = createIssuerInitiatedInteraction(t, kms, nil, createCredentialOfferIssuanceURI(t, "example.com", true),
@@ -415,13 +415,13 @@ func TestIssuerInitiatedInteraction_DynamicClientRegistration(t *testing.T) {
 		nil, false)
 
 	supported, err := interaction.DynamicClientRegistrationSupported()
-	requireErrorContains(t, err, "ISSUER_OPENID_CONFIG_FETCH_FAILED(OCI1-0003):failed to fetch issuer's "+
-		"OpenID configuration: openid configuration endpoint: Get")
+	requireErrorContains(t, err, "ISSUER_OPENID_CONFIG_FETCH_FAILED")
+	requireErrorContains(t, err, "failed to fetch issuer's OpenID configuration: openid configuration endpoint: Get")
 	require.False(t, supported)
 
 	endpoint, err := interaction.DynamicClientRegistrationEndpoint()
-	requireErrorContains(t, err, "ISSUER_OPENID_CONFIG_FETCH_FAILED(OCI1-0003):failed to fetch issuer's "+
-		"OpenID configuration: openid configuration endpoint: Get ")
+	requireErrorContains(t, err, "ISSUER_OPENID_CONFIG_FETCH_FAILED")
+	requireErrorContains(t, err, "failed to fetch issuer's OpenID configuration: openid configuration endpoint: Get ")
 	require.Empty(t, endpoint)
 }
 
@@ -499,8 +499,8 @@ func TestIssuerInitiatedInteractionAlias(t *testing.T) {
 	require.False(t, interaction.AuthorizationCodeGrantTypeSupported())
 
 	authCodeGrantParams, err := interaction.AuthorizationCodeGrantParams()
-	requireErrorContains(t, err,
-		"INVALID_SDK_USAGE(OCI3-0000):issuer does not support the authorization code grant")
+	requireErrorContains(t, err, "INVALID_SDK_USAGE")
+	requireErrorContains(t, err, "issuer does not support the authorization code grant")
 	require.Nil(t, authCodeGrantParams)
 
 	dynamicClientRegistrationSupported, err := interaction.DynamicClientRegistrationSupported()
@@ -508,8 +508,8 @@ func TestIssuerInitiatedInteractionAlias(t *testing.T) {
 	require.False(t, dynamicClientRegistrationSupported)
 
 	dynamicClientRegistrationEndpoint, err := interaction.DynamicClientRegistrationEndpoint()
-	requireErrorContains(t, err,
-		"INVALID_SDK_USAGE(OCI3-0000):issuer does not support dynamic client registration")
+	requireErrorContains(t, err, "INVALID_SDK_USAGE")
+	requireErrorContains(t, err, "issuer does not support dynamic client registration")
 	require.Empty(t, dynamicClientRegistrationEndpoint)
 
 	traceID := interaction.OTelTraceID()

--- a/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction_test.go
@@ -75,8 +75,8 @@ func TestWalletInitiatedInteraction_Flow(t *testing.T) {
 	require.False(t, dynamicClientRegistrationSupported)
 
 	dynamicClientRegistrationEndpoint, err := interaction.DynamicClientRegistrationEndpoint()
-	requireErrorContains(t, err,
-		"INVALID_SDK_USAGE(OCI3-0000):issuer does not support dynamic client registration")
+	requireErrorContains(t, err, "INVALID_SDK_USAGE")
+	requireErrorContains(t, err, "issuer does not support dynamic client registration")
 	require.Empty(t, dynamicClientRegistrationEndpoint)
 
 	credentialTypes := api.NewStringArray().Append("type")
@@ -107,7 +107,8 @@ func TestWalletInitiatedInteraction_Flow(t *testing.T) {
 
 func TestNewWalletInitiatedInteraction(t *testing.T) {
 	interaction, err := openid4ci.NewWalletInitiatedInteraction(nil, nil)
-	requireErrorContains(t, err, "INVALID_SDK_USAGE(OCI3-0000):args object must be provided")
+	requireErrorContains(t, err, "INVALID_SDK_USAGE")
+	requireErrorContains(t, err, "args object must be provided")
 	require.Nil(t, interaction)
 }
 
@@ -141,7 +142,8 @@ func TestWalletInitiatedInteraction_RequestCredential_Failure(t *testing.T) {
 	require.NotNil(t, interaction)
 
 	credentials, err := interaction.RequestCredential(nil, "", nil)
-	requireErrorContains(t, err, "INVALID_SDK_USAGE(OCI3-0000):verification method must be provided")
+	requireErrorContains(t, err, "INVALID_SDK_USAGE")
+	requireErrorContains(t, err, "verification method must be provided")
 	require.Nil(t, credentials)
 }
 

--- a/cmd/wallet-sdk-gomobile/walleterror/error.go
+++ b/cmd/wallet-sdk-gomobile/walleterror/error.go
@@ -17,7 +17,6 @@ type Error struct {
 	Category string `json:"category"`
 	Details  string `json:"details"`
 	TraceID  string `json:"trace_id"`
-	Full     string `json:"full"`
 }
 
 // Parse used to parse exception message on mobile side.

--- a/cmd/wallet-sdk-gomobile/wrapper/error.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/error.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/otel"
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/walleterror"
@@ -27,36 +28,52 @@ func ToMobileErrorWithTrace(err error, trace *otel.Trace) error {
 		return nil
 	}
 
+	gomobileError := convertToGomobileError(err, trace)
+
+	marshalledGomobileError, err := json.Marshal(gomobileError)
+	if err != nil {
+		return fmt.Errorf("failed to marshal error: %w", err)
+	}
+
+	return errors.New(string(marshalledGomobileError))
+}
+
+func convertToGomobileError(err error, trace *otel.Trace) *walleterror.Error {
 	traceID := ""
 	if trace != nil {
 		traceID = trace.TraceID()
 	}
 
-	var result *walleterror.Error
+	errorToExamine := err
 
-	var walletError *goapiwalleterror.Error
+	for errorToExamine != nil {
+		//nolint:errorlint // The linter wants us to use errors.As here, but we need to know the precise spot
+		// in the error chain where the higher-level non-goapiwalleterror.Errors end.
+		walletError, ok := errorToExamine.(*goapiwalleterror.Error)
+		if ok {
+			// If the highest-level error message it itself a goapiwalleterror.Error, then higherLevelErrorMessage
+			// will be a blank string, so walletError.ParentError will simply be passed through.
+			higherLevelErrorMessage := strings.ReplaceAll(err.Error(), walletError.Error(), "")
 
-	if errors.As(err, &walletError) {
-		result = &walleterror.Error{
-			Code:     walletError.Code,
-			Category: walletError.Scenario,
-			Details:  walletError.ParentError,
-			TraceID:  traceID,
-			Full:     err.Error(),
+			mergedErrorMessage := higherLevelErrorMessage + walletError.ParentError
+
+			return &walleterror.Error{
+				Code:     walletError.Code,
+				Category: walletError.Scenario,
+				Details:  mergedErrorMessage,
+				TraceID:  traceID,
+			}
 		}
-	} else {
-		result = &walleterror.Error{
-			Code:     "UKN2-000",
-			Category: "UNEXPECTED_ERROR",
-			Details:  err.Error(),
-			TraceID:  traceID,
-		}
+
+		errorToExamine = errors.Unwrap(errorToExamine)
 	}
 
-	formatted, fmtErr := json.Marshal(result)
-	if fmtErr != nil {
-		return fmt.Errorf("failed to marshal error: %w", fmtErr)
+	// There's no wallet Error in the chain, and so there's no error code available. Let's create a new
+	// gomobile wallet error using a generic code.
+	return &walleterror.Error{
+		Code:     "UKN2-000",
+		Category: "UNEXPECTED_ERROR",
+		Details:  err.Error(),
+		TraceID:  traceID,
 	}
-
-	return errors.New(string(formatted))
 }


### PR DESCRIPTION
This replaces the solution introduced in my previous commit where I added a "Full" field to the mobile error to give the caller a way to get the complete error message. This new solution allows the higher-level error messages to not be lost and also not require the caller to examine the parsed error message any differently.