### PR TITLE
feat(sdk): OpenID4VP error response parsing

### DIFF
--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction.go
@@ -103,7 +103,12 @@ func (i *IssuerInitiatedInteraction) CreateAuthorizationURL(clientID, redirectUR
 		goAPIOpts = append(goAPIOpts, openid4cigoapi.WithIssuerState(*opts.issuerState))
 	}
 
-	return i.goAPIInteraction.CreateAuthorizationURL(clientID, redirectURI, goAPIOpts...)
+	authorizationURL, err := i.goAPIInteraction.CreateAuthorizationURL(clientID, redirectURI, goAPIOpts...)
+	if err != nil {
+		return "", wrapper.ToMobileErrorWithTrace(err, i.oTel)
+	}
+
+	return authorizationURL, nil
 }
 
 // RequestCredentialWithPreAuth requests credential(s) from the issuer. This method can only be used for the

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
@@ -189,7 +189,8 @@ func TestIssuerInitiatedInteraction_CreateAuthorizationURL(t *testing.T) {
 			nil, false)
 
 		authorizationLink, err := interaction.CreateAuthorizationURL("clientID", "redirectURI", nil)
-		require.EqualError(t, err, "issuer does not support the authorization code grant type")
+		requireErrorContains(t, err, "INVALID_SDK_USAGE")
+		requireErrorContains(t, err, "issuer does not support the authorization code grant type")
 		require.Empty(t, authorizationLink)
 	})
 	t.Run("Conflicting issuer state", func(t *testing.T) {
@@ -203,7 +204,8 @@ func TestIssuerInitiatedInteraction_CreateAuthorizationURL(t *testing.T) {
 
 		authorizationLink, err := interaction.CreateAuthorizationURL("clientID", "redirectURI",
 			createAuthorizationURLOpts)
-		require.EqualError(t, err, "INVALID_SDK_USAGE(OCI3-0000):the credential offer already specifies "+
+		requireErrorContains(t, err, "INVALID_SDK_USAGE")
+		requireErrorContains(t, err, "the credential offer already specifies "+
 			"an issuer state, and a conflicting issuer state value was provided. An issuer state should only be "+
 			"provided if required by the issuer and the credential offer does not specify one already")
 		require.Empty(t, authorizationLink)
@@ -472,7 +474,8 @@ func TestIssuerInitiatedInteractionAlias(t *testing.T) {
 	// IssuerInitiatedInteraction) See TestIssuerInitiatedInteraction_RequestCredential or the integration tests for
 	// better examples.
 	authURL, err := interaction.CreateAuthorizationURL("", "", nil)
-	require.EqualError(t, err, "issuer does not support the authorization code grant type")
+	requireErrorContains(t, err, "INVALID_SDK_USAGE")
+	requireErrorContains(t, err, "issuer does not support the authorization code grant type")
 	require.Empty(t, authURL)
 
 	credentials, err = interaction.RequestCredentialWithPreAuth(nil, nil)

--- a/cmd/wallet-sdk-gomobile/walleterror/error.go
+++ b/cmd/wallet-sdk-gomobile/walleterror/error.go
@@ -26,8 +26,8 @@ func Parse(message string) *Error {
 	err := json.Unmarshal([]byte(message), walletErr)
 	if err != nil {
 		return &Error{
-			Code:     "GNR2-000",
-			Category: "GENERAL_ERROR",
+			Code:     "UKN2-000",
+			Category: "OTHER_ERROR",
 			Details:  message,
 		}
 	}

--- a/cmd/wallet-sdk-gomobile/wrapper/error.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/error.go
@@ -72,7 +72,7 @@ func convertToGomobileError(err error, trace *otel.Trace) *walleterror.Error {
 	// gomobile wallet error using a generic code.
 	return &walleterror.Error{
 		Code:     "UKN2-000",
-		Category: "UNEXPECTED_ERROR",
+		Category: "OTHER_ERROR",
 		Details:  err.Error(),
 		TraceID:  traceID,
 	}

--- a/cmd/wallet-sdk-gomobile/wrapper/error_test.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/error_test.go
@@ -48,7 +48,7 @@ func TestToMobileError(t *testing.T) {
 		parsedErr := walleterror.Parse(err.Error())
 
 		require.Equal(t, "UKN2-000", parsedErr.Code)
-		require.Equal(t, "UNEXPECTED_ERROR", parsedErr.Category)
+		require.Equal(t, "OTHER_ERROR", parsedErr.Category)
 		require.Equal(t, "regular Go error", parsedErr.Details)
 	})
 	t.Run("Non-goapiwalleterror.Error wrapped with another Non-goapiwalleterror.Error passed in", func(t *testing.T) {
@@ -60,7 +60,7 @@ func TestToMobileError(t *testing.T) {
 		parsedErr := walleterror.Parse(err.Error())
 
 		require.Equal(t, "UKN2-000", parsedErr.Code)
-		require.Equal(t, "UNEXPECTED_ERROR", parsedErr.Category)
+		require.Equal(t, "OTHER_ERROR", parsedErr.Category)
 		require.Equal(t, "higher-level error: regular Go error", parsedErr.Details)
 	})
 	t.Run("goapiwalleterror.Error wrapped by one higher-level non-goapiwalleterror.Error is passed in",

--- a/pkg/openid4ci/issuerinitiatedinteraction.go
+++ b/pkg/openid4ci/issuerinitiatedinteraction.go
@@ -127,7 +127,8 @@ func (i *IssuerInitiatedInteraction) CreateAuthorizationURL(clientID, redirectUR
 	opts ...CreateAuthorizationURLOpt,
 ) (string, error) {
 	if !i.AuthorizationCodeGrantTypeSupported() {
-		return "", errors.New("issuer does not support the authorization code grant type")
+		return "", walleterror.NewInvalidSDKUsageError(ErrorModule,
+			errors.New("issuer does not support the authorization code grant type"))
 	}
 
 	processedOpts := processCreateAuthorizationURLOpts(opts)

--- a/pkg/openid4vp/errors.go
+++ b/pkg/openid4vp/errors.go
@@ -9,20 +9,34 @@ package openid4vp
 // Constants' names and reasons are obvious so they do not require additional comments.
 // nolint:golint,nolintlint
 const (
-	module                                = "OVP"
-	RequestObjectFetchFailedError         = "REQUEST_OBJECT_FETCH_FAILED"
-	VerifyAuthorizationRequestFailedError = "VERIFY_AUTHORIZATION_REQUEST_FAILED"
-	CreateAuthorizedResponseFailedError   = "CREATE_AUTHORIZED_RESPONSE"
-	SendAuthorizedResponseFailedError     = "SEND_AUTHORIZED_RESPONSE"
-	NotInitializedProperlyError           = "NOT_INITIALIZED_PROPERLY"
+	ErrorModule                                 = "OVP"
+	RequestObjectFetchFailedError               = "REQUEST_OBJECT_FETCH_FAILED"
+	VerifyAuthorizationRequestFailedError       = "VERIFY_AUTHORIZATION_REQUEST_FAILED"
+	CreateAuthorizedResponseFailedError         = "CREATE_AUTHORIZED_RESPONSE_FAILED"
+	InvalidScopeError                           = "INVALID_SCOPE"
+	InvalidRequestError                         = "INVALID_REQUEST"
+	InvalidClientError                          = "INVALID_CLIENT"
+	VPFormatsNotSupportedError                  = "VP_FORMATS_NOT_SUPPORTED"
+	InvalidPresentationDefinitionURIError       = "INVALID_PRESENTATION_DEFINITION_URI"
+	InvalidPresentationDefinitionReferenceError = "INVALID_PRESENTATION_DEFINITION_REFERENCE"
+	OtherAuthorizationResponseError             = "OTHER_AUTHORIZATION_RESPONSE_ERROR"
 )
 
-// Constants' names and reasons are obvious so they do not require additional comments.
+// Constants' names and reasons are obvious, so they do not require additional comments.
 // nolint:golint,nolintlint
 const (
-	RequestObjectFetchFailedCode = iota
-	VerifyAuthorizationRequestFailedCode
-	CreateAuthorizedResponseFailedCode
-	SendAuthorizedResponseFailedCode
-	NotInitializedProperlyErrorCode
+	RequestObjectFetchFailedCode                    = 0
+	VerifyAuthorizationRequestFailedCode            = 1
+	CreateAuthorizedResponseFailedCode              = 2
+	InvalidScopeErrorCode                           = 3
+	InvalidRequestErrorCode                         = 4
+	InvalidClientErrorCode                          = 5
+	VPFormatsNotSupportedErrorCode                  = 6
+	InvalidPresentationDefinitionURIErrorCode       = 7
+	InvalidPresentationDefinitionReferenceErrorCode = 8
+	OtherAuthorizationResponseErrorCode             = 9
 )
+
+type errorResponse struct {
+	Error string `json:"error,omitempty"`
+}


### PR DESCRIPTION
* Added parsing for OpenID4VP error responses per the spec + new error codes.
*  For consistency, replaced one of the existing OpenID4VP error codes with the new "invalid SDK usage" error code type introduced in the OpenID4CI error handling commit.
* Previously, when errors without error type info were consumed in an app using the gomobile bindings, the default error code and category would differ depending on which layer the error processing was done (would be either GNR2-000/GENERAL_ERROR or UKN2-000/UNEXPECTED_ERROR). I've updated it so that we use the same error code and category in both places. I chose "OTHER_ERROR" for the category to try to be more descriptive/accurate of what the category is.