### PR TITLE
feat(app): Update the invalid pin error handling scenario

### DIFF
--- a/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
@@ -118,14 +118,6 @@ class MainActivity : FlutterActivity() {
                             }
                         }
 
-                        "fetchDID" -> {
-                            try {
-                                val didID = call.argument<String>("didID")
-                            } catch (e: Exception) {
-                                result.error("Exception", "Error while setting fetched DID", e)
-                            }
-                        }
-
                         "serializeDisplayData" -> {
                             try {
                                 val credentialDisplay = serializeDisplayData(call)
@@ -161,6 +153,15 @@ class MainActivity : FlutterActivity() {
                                 result.success(issuerURIResp)
                             } catch (e: Exception) {
                                 result.error("Exception", "Error while getting issuerURI", e)
+                            }
+                        }
+
+                        "parseWalletError" -> {
+                            try {
+                                val parsedWalletError = parseWalletSDKError(call)
+                                result.success(parsedWalletError)
+                            } catch (e: Exception) {
+                                result.error("Exception", "Error while parsing wallet sdk error", e)
                             }
                         }
 
@@ -400,7 +401,19 @@ class MainActivity : FlutterActivity() {
     }
 
 
+    private fun parseWalletSDKError(call: MethodCall): MutableMap<String, String> {
+        val localizedErrorMessage = call.argument<String>("localizedErrorMessage") ?: throw java.lang.Exception("localizedErrorMessage is missing")
 
+        val parsedError = Walleterror.parse(localizedErrorMessage)
+
+        val parsedErrResp: MutableMap<String, String> = mutableMapOf()
+        parsedErrResp["category"] = parsedError.category
+        parsedErrResp["details"] = parsedError.details
+        parsedErrResp["code"] = parsedError.code
+        parsedErrResp["traceID"] = parsedError.traceID
+
+        return parsedErrResp
+    }
     /**
      * ResolveDisplay resolves display information for issued credentials based on an issuer's metadata, which is fetched
     using the issuer's (base) URI. The CredentialDisplays returns DisplayData object correspond to the VCs passed in and are in the

--- a/demo/app/ios/Runner/flutterPlugin.swift
+++ b/demo/app/ios/Runner/flutterPlugin.swift
@@ -43,6 +43,10 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
             let otp = fetchArgsKeyValue(call, key: "otp")
             requestCredential(otp: otp!, result: result)
             
+        case "parseWalletSDKError":
+            let localizedErrorMessage = fetchArgsKeyValue(call, key: "localizedErrorMessage")
+            parseWalletSDKError(localizedErrorMessage: localizedErrorMessage!, result: result)
+            
         case "requestCredentialWithAuth":
             let redirectURIWithParams = fetchArgsKeyValue(call, key: "redirectURIWithParams")
             requestCredentialWithAuth(redirectURIWithParams: redirectURIWithParams!, result: result)
@@ -528,11 +532,26 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
                                                                      vcCredentials: convertToVerifiableCredentialsArray(credentials: vcCredentials))
             result(displayDataResp)
           } catch let error as NSError {
+              let parsedError = WalleterrorParse(error.localizedDescription)
                return result(FlutterError.init(code: "Exception",
                                          message: "error while resolving credential",
-                                         details: error.localizedDescription))
+                                               details: parsedError))
+              
             }
     }
+    
+    public func parseWalletSDKError(localizedErrorMessage: String, result: @escaping FlutterResult){
+        let parsedError = WalleterrorParse(localizedErrorMessage)!
+        
+        var parsedErrorResult :[String: Any] = [
+            "category":   parsedError.category,
+            "details":  parsedError.details,
+            "code":  parsedError.code,
+            "traceID":  parsedError.traceID
+        ]
+        result(parsedErrorResult)
+    }
+    
     
     public func resolveCredentialDisplay(arguments: Dictionary<String, Any>, result: @escaping FlutterResult){
    

--- a/demo/app/lib/views/credential_shared.dart
+++ b/demo/app/lib/views/credential_shared.dart
@@ -1,4 +1,3 @@
-import 'package:app/widgets/success_card.dart';
 import 'package:flutter/material.dart';
 import 'package:app/models/credential_data.dart';
 import 'package:app/widgets/credential_card.dart';
@@ -57,12 +56,12 @@ class CredentialSharedState extends State<CredentialShared> {
                 Image.asset('lib/assets/images/success.png')
               ],
             ),
-            title:  Text('Success',textAlign: TextAlign.left, style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+            title:  const Text('Success',textAlign: TextAlign.left, style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
             subtitle: Text("Credentials have been shared with ${widget.verifierName}", style: const TextStyle(fontSize: 14, fontWeight: FontWeight.normal)),
           ),
           Expanded(
             child: ListView.builder(
-              padding: EdgeInsets.only(left: 24, right:24, top: 24, bottom: 8),
+              padding: const EdgeInsets.only(left: 24, right:24, top: 24, bottom: 8),
               itemCount: widget.credentialData.length,
               itemBuilder: (BuildContext context, int index) {
                 return CredentialCard(credentialData: widget.credentialData[index], isDashboardWidget: true, isDetailArrowRequired: false,);

--- a/demo/app/lib/views/custom_error.dart
+++ b/demo/app/lib/views/custom_error.dart
@@ -2,7 +2,7 @@
 
 import 'package:flutter/material.dart';
 
-import '../widgets/common_title_appbar.dart';
+import 'package:app/widgets/common_title_appbar.dart';
 
 class CustomError extends StatefulWidget {
   final String requestErrorTitleMsg;

--- a/demo/app/lib/wallet_sdk/wallet_sdk_mobile.dart
+++ b/demo/app/lib/wallet_sdk/wallet_sdk_mobile.dart
@@ -4,6 +4,7 @@ Copyright Gen Digital Inc. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+import 'dart:convert';
 import 'dart:developer';
 
 import 'package:app/wallet_sdk/wallet_sdk_model.dart';
@@ -63,6 +64,12 @@ class WalletSDK extends WalletPlatform {
       debugPrint(error.toString());
       rethrow;
     }
+  }
+
+  Future<WalletSDKError> parseWalletSDKError({required String localizedErrorMessage}) async {
+    var parsedWalletError = await methodChannel.invokeMethod(
+        'parseWalletSDKError', <String, dynamic>{'localizedErrorMessage': localizedErrorMessage});
+    return WalletSDKError.fromJson(jsonDecode(json.encode(parsedWalletError)));
   }
 
   Future<String> requestCredentialWithAuth(String redirectURIWithParams) async {

--- a/demo/app/lib/wallet_sdk/wallet_sdk_model.dart
+++ b/demo/app/lib/wallet_sdk/wallet_sdk_model.dart
@@ -95,6 +95,43 @@ class SupportedCredentials {
   }
 }
 
+class WalletSDKError {
+  final String code;
+  final String category;
+  final String details;
+  final String traceID;
+
+  const WalletSDKError({
+    required this.code,
+    required this.category,
+    required this.details,
+    required this.traceID,
+  });
+
+  @override
+  String toString() {
+    return 'WalletSDKError { code: $code, category: $category, details: $details, traceID: $traceID }';
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['code'] = code;
+    data['category'] = category;
+    data['details'] = details;
+    data['traceID'] = traceID;
+    return data;
+  }
+
+  factory WalletSDKError.fromJson(Map<String, dynamic> json) {
+    return WalletSDKError(
+      code: json['code'],
+      category: json['category'],
+      details: json['details'],
+      traceID: json['traceID'],
+    );
+  }
+}
+
 class CredentialDisplayData {
   final String issuerName;
   final String overviewName;


### PR DESCRIPTION
- Used wallet sdk parsed error api to get the parsed details and category 
- Based on  parsed Category (INVALID_GRANT) a messaging is shown to the user **"Oops! Something went wrong! 
Try re-entering the pin or scan the new QR code."** 
- For the other categories we will show what ever is been sent in the details by parsed method. 
- If user has entered wrong pin they can try re-entering or restart the operation as per the messaging. 
   - If pin was wrong and user re-entered the right pin, user will be redirected to credential preview screen 

Things to fix: 
- Add a loader once the user hit the submit or renter button #509 
- Make the button submit/ Cancel button fix to the bottom right now they drag further to the Botton  when error widget appears #510
<img width="431" alt="invalid_pin_error" src="https://github.com/trustbloc/wallet-sdk/assets/7862595/81b690ec-f96d-4013-be29-222dca38e72d">
<img width="384" alt="invalid_pin_error_handling" src="https://github.com/trustbloc/wallet-sdk/assets/7862595/4b1c79ea-5316-4aec-8f9a-e4837dbdc6f3">
