### PR TITLE
feat(sdk): Issuance URI scheme validation

### DIFF
--- a/cmd/wallet-sdk-gomobile/docs/usage.md
+++ b/cmd/wallet-sdk-gomobile/docs/usage.md
@@ -911,10 +911,11 @@ let issuerURI = interaction.issuer().uri() // Optional (but useful)
 
 #### Creating New Interaction Object
 
-| Error                               | Possible Reasons                                                                                                                                                                                                                 |
-|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| INVALID_ISSUANCE_URI(OCI0-0000)     | The issuance URI used to initiate the OpenID4CI flow isn't a valid URL.<br/><br/>The issuance URI doesn't specify a credential offer.                                                                                            |
-| INVALID_CREDENTIAL_OFFER(OCI0-0001) | The credential offer object is malformed.<br/><br/>The issuance URI specified an endpoint for retrieving the credential offer, but there was an error during the GET call. The server may be down or have a configuration issue. |
+| Error                                      | Possible Reasons                                                                                                                                                                                                                 |
+|--------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| INVALID_ISSUANCE_URI(OCI0-0000)            | The issuance URI used to initiate the OpenID4CI flow isn't a valid URL.<br/><br/>The issuance URI doesn't specify a credential offer.                                                                                            |
+| INVALID_CREDENTIAL_OFFER(OCI0-0001)        | The credential offer object is malformed.<br/><br/>The issuance URI specified an endpoint for retrieving the credential offer, but there was an error during the GET call. The server may be down or have a configuration issue. |
+| UNSUPPORTED_ISSUANCE_URI_SCHEME(OCI0-0018) | The issuance URI used to initiate the OpenID4CI flow uses an unsupported scheme. Wallet-SDK only supports the "openid-credential-offer" scheme.                                                                                  |
 
 ##### Requesting Credential
 

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
@@ -802,7 +802,7 @@ func createCredentialOfferIssuanceURI(t *testing.T, issuerURL string, includeAut
 
 	credentialOfferEscaped := url.QueryEscape(string(credentialOfferBytes))
 
-	return "openid-vc://?credential_offer=" + credentialOfferEscaped
+	return "openid-credential-offer://?credential_offer=" + credentialOfferEscaped
 }
 
 func createCredentialOffer(t *testing.T, issuerURL string, includeAuthCodeGrant bool) *goapiopenid4ci.CredentialOffer {

--- a/pkg/openid4ci/errors.go
+++ b/pkg/openid4ci/errors.go
@@ -29,6 +29,7 @@ const (
 	UnsupportedCredentialFormatError          = "UNSUPPORTED_CREDENTIAL_FORMAT"
 	UnsupportedCredentialTypeError            = "UNSUPPORTED_CREDENTIAL_TYPE"
 	InvalidOrMissingProofError                = "INVALID_OR_MISSING_PROOF"
+	UnsupportedIssuanceURISchemeError         = "UNSUPPORTED_ISSUANCE_URI_SCHEME"
 )
 
 // Constants' names and reasons are obvious, so they do not require additional comments.
@@ -53,4 +54,5 @@ const (
 	UnsupportedCredentialFormatErrorCode     = 16
 	UnsupportedCredentialTypeErrorCode       = 17
 	InvalidOrMissingProofErrorCode           = 18
+	UnsupportedIssuanceURISchemeCode
 )

--- a/pkg/openid4ci/interaction.go
+++ b/pkg/openid4ci/interaction.go
@@ -391,6 +391,9 @@ func (i *interaction) createClaimsProof(nonce interface{}, signer api.JWTSigner)
 	return proofJWT, nil
 }
 
+// createOAuthHTTPClient creates the OAuth2 client wrapper using the OAuth2 library.
+// Due to some peculiarities with the OAuth2 library, we need to do some things here to ensure our custom HTTP client
+// settings get preserved. Check the comments in the method below for more details.
 func (i *interaction) createOAuthHTTPClient() *http.Client {
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, i.httpClient)
 

--- a/pkg/openid4ci/issuerinitiatedinteraction.go
+++ b/pkg/openid4ci/issuerinitiatedinteraction.go
@@ -453,10 +453,6 @@ func tokenErrorResponseHandler(statusCode int, respBody []byte) error {
 	}
 }
 
-// createOAuthHTTPClient creates the OAuth2 client wrapper using the OAuth2 library.
-// Due to some peculiarities with the OAuth2 library, we need to do some things here to ensure our custom HTTP client
-// settings get preserved. Check the comments in the method below for more details.
-
 func getCredentialOffer(initiateIssuanceURI string, httpClient *http.Client, metricsLogger api.MetricsLogger,
 ) (*CredentialOffer, error) {
 	requestURIParsed, err := url.Parse(initiateIssuanceURI)
@@ -466,6 +462,14 @@ func getCredentialOffer(initiateIssuanceURI string, httpClient *http.Client, met
 			InvalidIssuanceURICode,
 			InvalidIssuanceURIError,
 			err)
+	}
+
+	if requestURIParsed.Scheme != "openid-credential-offer" {
+		return nil, walleterror.NewValidationError(
+			ErrorModule,
+			UnsupportedIssuanceURISchemeCode,
+			UnsupportedIssuanceURISchemeError,
+			fmt.Errorf("%s is not a supported issuance URL scheme", requestURIParsed.Scheme))
 	}
 
 	var credentialOfferJSON []byte

--- a/pkg/openid4ci/issuerinitiatedinteraction_test.go
+++ b/pkg/openid4ci/issuerinitiatedinteraction_test.go
@@ -165,7 +165,7 @@ func TestNewInteraction(t *testing.T) {
 
 			credentialOfferEscaped := url.QueryEscape(string(credentialOfferBytes))
 
-			credentialOfferIssuanceURI := "openid-vc://?credential_offer=" + credentialOfferEscaped
+			credentialOfferIssuanceURI := "openid-credential-offer://?credential_offer=" + credentialOfferEscaped
 
 			newIssuerInitiatedInteraction(t, credentialOfferIssuanceURI)
 		})
@@ -193,7 +193,8 @@ func TestNewInteraction(t *testing.T) {
 	})
 	t.Run("Fail to get credential offer", func(t *testing.T) {
 		t.Run("Credential offer query parameter missing", func(t *testing.T) {
-			interaction, err := openid4ci.NewIssuerInitiatedInteraction("", getTestClientConfig(t))
+			interaction, err := openid4ci.NewIssuerInitiatedInteraction("openid-credential-offer://",
+				getTestClientConfig(t))
 			require.EqualError(t, err, "INVALID_ISSUANCE_URI(OCI0-0000):credential offer query "+
 				"parameter missing from initiate issuance URI")
 			require.Nil(t, interaction)
@@ -248,7 +249,7 @@ func TestNewInteraction(t *testing.T) {
 
 		credentialOfferEscaped := url.QueryEscape(string(credentialOfferBytes))
 
-		credentialOfferIssuanceURI := "openid-vc://?credential_offer=" + credentialOfferEscaped
+		credentialOfferIssuanceURI := "openid-credential-offer://?credential_offer=" + credentialOfferEscaped
 
 		interaction, err := openid4ci.NewIssuerInitiatedInteraction(credentialOfferIssuanceURI, getTestClientConfig(t))
 		require.EqualError(t, err, "no supported grant types found")
@@ -264,7 +265,7 @@ func TestNewInteraction(t *testing.T) {
 
 		credentialOfferEscaped := url.QueryEscape(string(credentialOfferBytes))
 
-		credentialOfferIssuanceURI := "openid-vc://?credential_offer=" + credentialOfferEscaped
+		credentialOfferIssuanceURI := "openid-credential-offer://?credential_offer=" + credentialOfferEscaped
 
 		interaction, err := openid4ci.NewIssuerInitiatedInteraction(credentialOfferIssuanceURI, getTestClientConfig(t))
 		require.EqualError(t, err, "UNSUPPORTED_CREDENTIAL_TYPE_IN_OFFER(OCI0-0002):unsupported "+
@@ -298,6 +299,13 @@ func TestNewInteraction(t *testing.T) {
 		require.Contains(t, err.Error(),
 			"failed to log event (Event=Fetch credential offer via an HTTP GET request to "+
 				"http://127.0.0.1:")
+		require.Nil(t, interaction)
+	})
+	t.Run("Issuance URL using an unsupported scheme", func(t *testing.T) {
+		interaction, err := openid4ci.NewIssuerInitiatedInteraction("https://SomeCredentialOffer",
+			getTestClientConfig(t))
+		testutil.RequireErrorContains(t, err, "UNSUPPORTED_ISSUANCE_URI_SCHEME")
+		testutil.RequireErrorContains(t, err, "https is not a supported issuance URL scheme")
 		require.Nil(t, interaction)
 	})
 }
@@ -1590,7 +1598,7 @@ func createCredentialOfferIssuanceURI(t *testing.T, issuerURL string, includeAut
 
 	credentialOfferEscaped := url.QueryEscape(string(credentialOfferBytes))
 
-	return "openid-vc://?credential_offer=" + credentialOfferEscaped
+	return "openid-credential-offer://?credential_offer=" + credentialOfferEscaped
 }
 
 func createCredentialOffer(t *testing.T, issuerURL string, includeAuthCodeGrant,


### PR DESCRIPTION
* When instantiating an issuer-initiated interaction object, we now enforce that it must use the openid-credential-offer scheme.
* Also fixed a misplaced comment.