### PR TITLE
feat(sdk)!: Ability to get issuer metadata in mobile bindings

### DIFF
--- a/cmd/wallet-sdk-gomobile/docs/usage.md
+++ b/cmd/wallet-sdk-gomobile/docs/usage.md
@@ -538,10 +538,12 @@ know this, you're ready to [request credentials](#request-credential).
 
 #### Authorization Code Flow
 
-If you are using a `WalletInitiatedInteraction`, then you have the option of checking what credentials the issuer
-supports. To do this call the `SupportedCredentials` method and use the methods on the returned object to see what
+If you are using a `WalletInitiatedInteraction`, then you may want to check what credentials the issuer
+supports. To do this call the `issuerMetadata` method, and then call the `supportedCredentials` method on the returned
+`IssuerMetadata` object. Then, use the methods on the returned `SupportedCredentials` object to see what
 credential formats and types are supported. If you already know what credential format+types you want, then you can
-skip this step.
+skip this step. Note that if you're using an `IssuerInitiatedInteraction` then the credential format+types are already
+pre-specified by the issuer in the credential offer and can't be overridden.
 
 To begin the Authorization Code flow, you need to create an authorization URL. To do this, call the `createAuthorizationURL` method on the
 `Interaction` object. You need to provide the following parameters:

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction.go
@@ -250,6 +250,16 @@ func (i *IssuerInitiatedInteraction) DynamicClientRegistrationEndpoint() (string
 	return endpoint, nil
 }
 
+// IssuerMetadata returns the issuer's metadata.
+func (i *IssuerInitiatedInteraction) IssuerMetadata() (*IssuerMetadata, error) {
+	goAPIIssuerMetadata, err := i.goAPIInteraction.IssuerMetadata()
+	if err != nil {
+		return nil, wrapper.ToMobileErrorWithTrace(err, i.oTel)
+	}
+
+	return &IssuerMetadata{issuerMetadata: goAPIIssuerMetadata}, nil
+}
+
 // OTelTraceID returns the OpenTelemetry trace ID.
 // If OpenTelemetry has been disabled, then an empty string is returned.
 func (i *IssuerInitiatedInteraction) OTelTraceID() string {

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
@@ -427,6 +427,22 @@ func TestIssuerInitiatedInteraction_DynamicClientRegistration(t *testing.T) {
 	require.Empty(t, endpoint)
 }
 
+func TestIssuerInitiatedInteraction_IssuerMetadata(t *testing.T) {
+	t.Run("Failed to get issuer metadata", func(t *testing.T) {
+		kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
+		require.NoError(t, err)
+
+		i := createIssuerInitiatedInteraction(t, kms, nil,
+			createCredentialOfferIssuanceURI(t, "example.com", false),
+			nil, false)
+		require.NotEmpty(t, i.OTelTraceID())
+
+		issuerMetadata, err := i.IssuerMetadata()
+		requireErrorContains(t, err, "METADATA_FETCH_FAILED")
+		require.Nil(t, issuerMetadata)
+	})
+}
+
 // The IssuerInitiatedInteraction alias type (Interaction) should behave the same as the
 // IssuerInitiatedInteraction object, since it's just a wrapper for it.
 func TestIssuerInitiatedInteractionAlias(t *testing.T) {
@@ -517,6 +533,10 @@ func TestIssuerInitiatedInteractionAlias(t *testing.T) {
 
 	traceID := interaction.OTelTraceID()
 	require.NotEmpty(t, traceID)
+
+	issuerMetadata, err := interaction.IssuerMetadata()
+	require.NoError(t, err)
+	require.NotNil(t, issuerMetadata)
 }
 
 //nolint:thelper // Not a test helper function
@@ -597,6 +617,10 @@ func doRequestCredentialTest(t *testing.T, additionalHeaders *api.Headers,
 
 	subjectID := subjectIDs.AtIndex(0)
 	require.Equal(t, "did:orb:uAAA:EiARTvvCsWFTSCc35447YpI2MJpFAaJZtFlceVz9lcMYVw", subjectID)
+
+	issuerMetadata, err := interaction.IssuerMetadata()
+	require.NoError(t, err)
+	require.NotNil(t, issuerMetadata)
 }
 
 func createIssuerInitiatedInteraction(t *testing.T, kms *localkms.KMS, activityLogger api.ActivityLogger,

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteractionalias.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteractionalias.go
@@ -175,6 +175,15 @@ func (i *Interaction) DynamicClientRegistrationEndpoint() (string, error) {
 	return i.issuerInitiatedInteraction.DynamicClientRegistrationEndpoint()
 }
 
+// IssuerMetadata is an alias for the method with the same name on the IssuerInitiatedInteraction
+// object.
+//
+// Deprecated: This only exists for backwards compatibility with code that hasn't been updated to the latest version of
+// Wallet-SDK and will be removed in a future version.
+func (i *Interaction) IssuerMetadata() (*IssuerMetadata, error) {
+	return i.issuerInitiatedInteraction.IssuerMetadata()
+}
+
 // OTelTraceID is an alias for the method with the same name on the IssuerInitiatedInteraction object.
 //
 // Deprecated: This only exists for backwards compatibility with code that hasn't been updated to the latest version of

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuermetadata.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuermetadata.go
@@ -1,0 +1,32 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package openid4ci
+
+import (
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+)
+
+// IssuerMetadata represents metadata about an issuer as obtained from their .well-known OpenID configuration.
+type IssuerMetadata struct {
+	issuerMetadata *issuer.Metadata
+}
+
+// CredentialIssuer returns the issuer's identifier.
+func (i *IssuerMetadata) CredentialIssuer() string {
+	return i.issuerMetadata.CredentialIssuer
+}
+
+// SupportedCredentials returns an object that can be used to determine the types of credentials that the issuer
+// supports issuance of.
+func (i *IssuerMetadata) SupportedCredentials() *SupportedCredentials {
+	return &SupportedCredentials{supportedCredentials: i.issuerMetadata.CredentialsSupported}
+}
+
+// LocalizedIssuerDisplays returns an object that contains display information for the issuer in various locales.
+func (i *IssuerMetadata) LocalizedIssuerDisplays() *LocalizedIssuerDisplays {
+	return &LocalizedIssuerDisplays{localizedIssuerDisplays: i.issuerMetadata.LocalizedIssuerDisplays}
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuermetadata_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuermetadata_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package openid4ci_test
+
+import (
+	_ "embed"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/localkms"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/openid4ci"
+)
+
+//go:embed testdata/sample_issuer_metadata.json
+var sampleIssuerMetadata string
+
+func TestIssuerMetadata(t *testing.T) {
+	issuerServerHandler := &mockIssuerServerHandler{
+		t:              t,
+		issuerMetadata: sampleIssuerMetadata,
+	}
+	server := httptest.NewServer(issuerServerHandler)
+
+	defer server.Close()
+
+	requestURI := createCredentialOfferIssuanceURI(t, server.URL, false)
+
+	kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
+	require.NoError(t, err)
+
+	interactionRequiredArgs, interactionOptionalArgs := getTestArgs(t, requestURI, kms,
+		nil, nil, false)
+
+	interaction, err := openid4ci.NewIssuerInitiatedInteraction(interactionRequiredArgs, interactionOptionalArgs)
+	require.NoError(t, err)
+
+	issuerMetadata, err := interaction.IssuerMetadata()
+	require.NoError(t, err)
+
+	credentialIssuer := issuerMetadata.CredentialIssuer()
+	require.Equal(t, "https://server.example.com", credentialIssuer)
+
+	localizedIssuerDisplays := issuerMetadata.LocalizedIssuerDisplays()
+	require.NotNil(t, localizedIssuerDisplays)
+	require.Equal(t, 2, localizedIssuerDisplays.Length())
+
+	firstLocalizedDisplay := localizedIssuerDisplays.AtIndex(0)
+	require.Equal(t, "Example University", firstLocalizedDisplay.Name())
+	require.Equal(t, "en-US", firstLocalizedDisplay.Locale())
+
+	secondLocalizedDisplay := localizedIssuerDisplays.AtIndex(1)
+	require.Equal(t, "サンプル大学", secondLocalizedDisplay.Name())
+	require.Equal(t, "jp-JA", secondLocalizedDisplay.Locale())
+
+	require.Nil(t, localizedIssuerDisplays.AtIndex(2))
+
+	supportedCredentials := issuerMetadata.SupportedCredentials()
+	require.NotNil(t, supportedCredentials)
+	require.Equal(t, 1, supportedCredentials.Length())
+
+	supportedCredential := supportedCredentials.AtIndex(0)
+	require.NotNil(t, supportedCredential)
+	require.Equal(t, "jwt_vc_json", supportedCredential.Format())
+	require.Equal(t, "UniversityDegreeCredential", supportedCredential.ID())
+
+	types := supportedCredential.Types()
+	require.NotNil(t, types)
+	require.Equal(t, 2, types.Length())
+	require.Equal(t, "VerifiableCredential", types.AtIndex(0))
+	require.Equal(t, "UniversityDegreeCredential", types.AtIndex(1))
+
+	require.Nil(t, supportedCredentials.AtIndex(1))
+
+	localizedDisplays := supportedCredential.LocalizedDisplays()
+	require.NotNil(t, localizedDisplays)
+	require.Equal(t, 1, localizedDisplays.Length())
+
+	localizedDisplay := localizedDisplays.AtIndex(0)
+	require.NotNil(t, localizedDisplay)
+	require.Equal(t, "University Credential", localizedDisplay.Name())
+	require.Equal(t, "en-US", localizedDisplay.Locale())
+	require.Equal(t, "#12107c", localizedDisplay.BackgroundColor())
+	require.Equal(t, "#FFFFFF", localizedDisplay.TextColor())
+
+	credentialLogo := localizedDisplay.Logo()
+	require.NotNil(t, credentialLogo)
+	require.Equal(t, "https://exampleuniversity.com/public/logo.png", credentialLogo.URL())
+	require.Equal(t, "a square logo of a university", credentialLogo.AltText())
+
+	require.Nil(t, localizedDisplays.AtIndex(1))
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/localizedcredentialdisplay.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/localizedcredentialdisplay.go
@@ -1,0 +1,60 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package openid4ci
+
+import "github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+
+// LocalizedCredentialDisplays represents display information for a credential in various locales.
+type LocalizedCredentialDisplays struct {
+	localizedCredentialDisplays []issuer.LocalizedCredentialDisplay
+}
+
+// AtIndex returns the LocalizedCredentialDisplays at the given index.
+// If the index passed in is out of bounds, then nil is returned.
+func (l *LocalizedCredentialDisplays) AtIndex(index int) *LocalizedCredentialDisplay {
+	maxIndex := len(l.localizedCredentialDisplays) - 1
+	if index > maxIndex || index < 0 {
+		return nil
+	}
+
+	return &LocalizedCredentialDisplay{localizedCredentialDisplay: &l.localizedCredentialDisplays[index]}
+}
+
+// Length returns the number of LocalizedIssuerDisplays contained within this object.
+func (l *LocalizedCredentialDisplays) Length() int {
+	return len(l.localizedCredentialDisplays)
+}
+
+// LocalizedCredentialDisplay represents display information for a credential in a specific locale.
+type LocalizedCredentialDisplay struct {
+	localizedCredentialDisplay *issuer.LocalizedCredentialDisplay
+}
+
+// Name returns this LocalizedCredentialDisplay's name.
+func (l *LocalizedCredentialDisplay) Name() string {
+	return l.localizedCredentialDisplay.Name
+}
+
+// Locale returns this LocalizedCredentialDisplay's locale.
+func (l *LocalizedCredentialDisplay) Locale() string {
+	return l.localizedCredentialDisplay.Locale
+}
+
+// Logo returns this LocalizedCredentialDisplay's logo.
+func (l *LocalizedCredentialDisplay) Logo() *Logo {
+	return &Logo{logo: l.localizedCredentialDisplay.Logo}
+}
+
+// BackgroundColor returns this LocalizedCredentialDisplay's background color.
+func (l *LocalizedCredentialDisplay) BackgroundColor() string {
+	return l.localizedCredentialDisplay.BackgroundColor
+}
+
+// TextColor returns this LocalizedCredentialDisplay's text color.
+func (l *LocalizedCredentialDisplay) TextColor() string {
+	return l.localizedCredentialDisplay.TextColor
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/localizedissuerdisplay.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/localizedissuerdisplay.go
@@ -1,0 +1,45 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package openid4ci
+
+import "github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+
+// LocalizedIssuerDisplays represents display information for an issuer in various locales.
+type LocalizedIssuerDisplays struct {
+	localizedIssuerDisplays []issuer.LocalizedIssuerDisplay
+}
+
+// AtIndex returns the LocalizedIssuerDisplays at the given index.
+// If the index passed in is out of bounds, then nil is returned.
+func (l *LocalizedIssuerDisplays) AtIndex(index int) *LocalizedIssuerDisplay {
+	maxIndex := len(l.localizedIssuerDisplays) - 1
+	if index > maxIndex || index < 0 {
+		return nil
+	}
+
+	return &LocalizedIssuerDisplay{localizedIssuerDisplay: &l.localizedIssuerDisplays[index]}
+}
+
+// Length returns the number of LocalizedIssuerDisplays contained within this object.
+func (l *LocalizedIssuerDisplays) Length() int {
+	return len(l.localizedIssuerDisplays)
+}
+
+// LocalizedIssuerDisplay represents display information for an issuer in a specific locale.
+type LocalizedIssuerDisplay struct {
+	localizedIssuerDisplay *issuer.LocalizedIssuerDisplay
+}
+
+// Name returns this LocalizedIssuerDisplay's name.
+func (l *LocalizedIssuerDisplay) Name() string {
+	return l.localizedIssuerDisplay.Name
+}
+
+// Locale returns this LocalizedIssuerDisplay's Locale.
+func (l *LocalizedIssuerDisplay) Locale() string {
+	return l.localizedIssuerDisplay.Locale
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/logo.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/logo.go
@@ -1,0 +1,24 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package openid4ci
+
+import "github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+
+// Logo represents display information for a logo.
+type Logo struct {
+	logo *issuer.Logo
+}
+
+// URL returns the URL where this logo's image can be fetched.
+func (l *Logo) URL() string {
+	return l.logo.URL
+}
+
+// AltText returns alt text for this logo.
+func (l *Logo) AltText() string {
+	return l.logo.AltText
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/supportedcredential.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/supportedcredential.go
@@ -8,26 +8,21 @@ package openid4ci
 
 import (
 	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
-	openid4cigoapi "github.com/trustbloc/wallet-sdk/pkg/openid4ci"
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
 )
 
 // SupportedCredentials represents the credentials (types and formats) that an issuer can issue.
 type SupportedCredentials struct {
-	supportedCredentials []openid4cigoapi.SupportedCredential
+	supportedCredentials []issuer.SupportedCredential
 }
 
-// SupportedCredential represents a specific credential (type and format) that an issuer can issue.
-type SupportedCredential struct {
-	supportedCredential *openid4cigoapi.SupportedCredential
-}
-
-// Length returns the number of SupportCredentials contained within this object.
+// Length returns the number of SupportedCredentials contained within this object.
 func (s *SupportedCredentials) Length() int {
 	return len(s.supportedCredentials)
 }
 
-// AtIndex returns the SupportCredential at the given index.
-// If the index passed in is out of bounds, then a nil is returned.
+// AtIndex returns the SupportedCredential at the given index.
+// If the index passed in is out of bounds, then nil is returned.
 func (s *SupportedCredentials) AtIndex(index int) *SupportedCredential {
 	maxIndex := len(s.supportedCredentials) - 1
 	if index > maxIndex || index < 0 {
@@ -35,6 +30,11 @@ func (s *SupportedCredentials) AtIndex(index int) *SupportedCredential {
 	}
 
 	return &SupportedCredential{supportedCredential: &s.supportedCredentials[index]}
+}
+
+// SupportedCredential represents a specific credential (type and format) that an issuer can issue.
+type SupportedCredential struct {
+	supportedCredential *issuer.SupportedCredential
 }
 
 // Format returns this SupportedCredential's format.
@@ -45,4 +45,14 @@ func (s *SupportedCredential) Format() string {
 // Types returns this SupportedCredential's types.
 func (s *SupportedCredential) Types() *api.StringArray {
 	return &api.StringArray{Strings: s.supportedCredential.Types}
+}
+
+// ID returns this SupportedCredential's ID.
+func (s *SupportedCredential) ID() string {
+	return s.supportedCredential.ID
+}
+
+// LocalizedDisplays returns an object that contains this SupportedCredential's display data in various locales.
+func (s *SupportedCredential) LocalizedDisplays() *LocalizedCredentialDisplays {
+	return &LocalizedCredentialDisplays{localizedCredentialDisplays: s.supportedCredential.LocalizedCredentialDisplays}
 }

--- a/cmd/wallet-sdk-gomobile/openid4ci/testdata/sample_issuer_metadata.json
+++ b/cmd/wallet-sdk-gomobile/openid4ci/testdata/sample_issuer_metadata.json
@@ -1,0 +1,113 @@
+{
+  "credential_issuer":"https://server.example.com",
+  "authorization_server":"https://server.example.com/oidc/authorize",
+  "credential_endpoint":"https://server.example.com/oidc/credential",
+  "display":[
+    {
+      "locale":"en-US",
+      "name":"Example University"
+    },
+    {
+      "name":"サンプル大学",
+      "locale":"jp-JA"
+    }
+  ],
+  "credentials_supported":[
+    {
+      "id": "UniversityDegreeCredential",
+      "format":"jwt_vc_json",
+      "types":[
+        "VerifiableCredential",
+        "UniversityDegreeCredential"
+      ],
+      "credentialSubject":{
+        "id":{
+          "display":[
+            {
+              "name":"ID",
+              "locale":"en-US"
+            }
+          ],
+          "value_type":"string",
+          "order":0
+        },
+        "given_name":{
+          "display":[
+            {
+              "name":"Given Name",
+              "locale":"en-US"
+            }
+          ],
+          "value_type":"string",
+          "order":1
+        },
+        "surname":{
+          "display":[
+            {
+              "name":"Surname",
+              "locale":"en-US"
+            }
+          ],
+          "value_type":"string",
+          "order":2
+        },
+        "gpa":{
+          "display":[
+            {
+              "name":"GPA",
+              "locale":"en-US"
+            }
+          ],
+          "value_type":"number"
+        },
+        "sensitive_id":{
+          "display":[
+            {
+              "name":"Sensitive ID",
+              "locale":"en-US"
+            }
+          ],
+          "value_type":"string",
+          "mask":"regex(^(.*).{4}$)"
+        },
+        "really_sensitive_id":{
+          "display":[
+            {
+              "name":"Really Sensitive ID",
+              "locale":"en-US"
+            }
+          ],
+          "value_type":"string",
+          "mask":"regex((.*))"
+        },
+        "chemistry":{
+          "display":[
+            {
+              "name":"Chemistry Final Grade",
+              "locale":"en-US"
+            }
+          ],
+          "value_type":"number"
+        }
+      },
+      "cryptographic_binding_methods_supported":[
+        "ion"
+      ],
+      "cryptographic_suites_supported":[
+        "ECDSASecp256k1DER"
+      ],
+      "display":[
+        {
+          "name":"University Credential",
+          "locale":"en-US",
+          "logo":{
+            "url":"https://exampleuniversity.com/public/logo.png",
+            "alt_text":"a square logo of a university"
+          },
+          "background_color":"#12107c",
+          "text_color":"#FFFFFF"
+        }
+      ]
+    }
+  ]
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction.go
@@ -93,16 +93,6 @@ func NewWalletInitiatedInteraction( //nolint: dupl // Similar looking but for di
 	}, nil
 }
 
-// SupportedCredentials returns the credential types and formats that an issuer can issue.
-func (i *WalletInitiatedInteraction) SupportedCredentials() (*SupportedCredentials, error) {
-	goAPISupportedCredentials, err := i.goAPIInteraction.SupportedCredentials()
-	if err != nil {
-		return nil, wrapper.ToMobileErrorWithTrace(err, i.oTel)
-	}
-
-	return &SupportedCredentials{supportedCredentials: goAPISupportedCredentials}, nil
-}
-
 // CreateAuthorizationURL creates an authorization URL that can be opened in a browser to proceed to the login page.
 // It must be called before calling the RequestCredential method.
 // It creates the authorization URL that can be opened in a browser to proceed to the login page.
@@ -181,6 +171,16 @@ func (i *WalletInitiatedInteraction) DynamicClientRegistrationEndpoint() (string
 	}
 
 	return endpoint, nil
+}
+
+// IssuerMetadata returns the issuer's metadata object.
+func (i *WalletInitiatedInteraction) IssuerMetadata() (*IssuerMetadata, error) {
+	goAPIIssuerMetadata, err := i.goAPIInteraction.IssuerMetadata()
+	if err != nil {
+		return nil, wrapper.ToMobileErrorWithTrace(err, i.oTel)
+	}
+
+	return &IssuerMetadata{issuerMetadata: goAPIIssuerMetadata}, nil
 }
 
 func (i *WalletInitiatedInteraction) createSigner(vm *api.VerificationMethod) (*common.JWSSigner, error) {

--- a/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction_test.go
@@ -54,10 +54,11 @@ func TestWalletInitiatedInteraction_Flow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, interaction)
 
-	supportedCredentials, err := interaction.SupportedCredentials()
+	issuerMetadata, err := interaction.IssuerMetadata()
 	require.NoError(t, err)
-	require.NotNil(t, supportedCredentials)
+	require.NotNil(t, issuerMetadata)
 
+	supportedCredentials := issuerMetadata.SupportedCredentials()
 	require.Equal(t, 2, supportedCredentials.Length())
 
 	require.Equal(t, "jwt_vc_json", supportedCredentials.AtIndex(0).Format())

--- a/demo/app/ios/Runner/WalletInitiatedOpenID4CI.swift
+++ b/demo/app/ios/Runner/WalletInitiatedOpenID4CI.swift
@@ -29,7 +29,7 @@ public class WalletInitiatedOpenID4CI {
     }
     
     func getSupportedCredentials() throws -> Openid4ciSupportedCredentials{
-        return try walletInitiatedInteraction.supportedCredentials()
+        return try walletInitiatedInteraction.issuerMetadata().supportedCredentials()!
     }
     
     func requestCredentialWithWalletInitiatedFlow(didVerificationMethod: ApiVerificationMethod, redirectURIWithParams: String) throws -> VerifiableCredential {

--- a/pkg/credentialschema/credentialdisplay.go
+++ b/pkg/credentialschema/credentialdisplay.go
@@ -168,7 +168,7 @@ func resolveClaims(supportedCredential *issuer.SupportedCredential, credentialSu
 func resolveClaim(fieldName string, claim *issuer.Claim, credentialSubject *verifiable.Subject,
 	preferredLocale string,
 ) (*ResolvedClaim, error) {
-	if len(claim.Displays) == 0 {
+	if len(claim.LocalizedClaimDisplays) == 0 {
 		return nil, errNoClaimDisplays
 	}
 
@@ -226,16 +226,16 @@ func getMaskedValue(rawValue, maskingPattern string) (string, error) {
 // on what is available). If no preferred locale is specified, then the first available locale is used.
 func getLocalizedLabel(preferredLocale string, claim *issuer.Claim) (string, string) {
 	if preferredLocale == "" {
-		return claim.Displays[0].Name, claim.Displays[0].Locale
+		return claim.LocalizedClaimDisplays[0].Name, claim.LocalizedClaimDisplays[0].Locale
 	}
 
-	for _, claimDisplay := range claim.Displays {
+	for _, claimDisplay := range claim.LocalizedClaimDisplays {
 		if strings.EqualFold(preferredLocale, claimDisplay.Locale) {
 			return claimDisplay.Name, claimDisplay.Locale
 		}
 	}
 
-	return claim.Displays[0].Name, claim.Displays[0].Locale
+	return claim.LocalizedClaimDisplays[0].Name, claim.LocalizedClaimDisplays[0].Locale
 }
 
 // Returns nil if no matching claim value could be found.
@@ -282,20 +282,20 @@ func getOverviewDisplay(supportedCredential *issuer.SupportedCredential,
 	preferredLocale string,
 ) *CredentialOverview {
 	if preferredLocale == "" {
-		return issuerCredentialDisplayToResolvedCredentialOverview(&supportedCredential.Overview[0])
+		return issuerCredentialDisplayToResolvedCredentialOverview(&supportedCredential.LocalizedCredentialDisplays[0])
 	}
 
-	for i := range supportedCredential.Overview {
-		if strings.EqualFold(preferredLocale, supportedCredential.Overview[i].Locale) {
-			return issuerCredentialDisplayToResolvedCredentialOverview(&supportedCredential.Overview[i])
+	for i := range supportedCredential.LocalizedCredentialDisplays {
+		if strings.EqualFold(preferredLocale, supportedCredential.LocalizedCredentialDisplays[i].Locale) {
+			return issuerCredentialDisplayToResolvedCredentialOverview(&supportedCredential.LocalizedCredentialDisplays[i])
 		}
 	}
 
-	return issuerCredentialDisplayToResolvedCredentialOverview(&supportedCredential.Overview[0])
+	return issuerCredentialDisplayToResolvedCredentialOverview(&supportedCredential.LocalizedCredentialDisplays[0])
 }
 
 func issuerCredentialDisplayToResolvedCredentialOverview(
-	issuerCredentialOverview *issuer.CredentialOverview,
+	issuerCredentialOverview *issuer.LocalizedCredentialDisplay,
 ) *CredentialOverview {
 	resolvedCredentialOverview := &CredentialOverview{
 		Name:            issuerCredentialOverview.Name,

--- a/pkg/credentialschema/credentialschema.go
+++ b/pkg/credentialschema/credentialschema.go
@@ -22,7 +22,7 @@ func Resolve(opts ...ResolveOpt) (*ResolvedDisplayData, error) {
 		return nil, err
 	}
 
-	issuerOverview := getIssuerDisplay(metadata.IssuerDisplays, preferredLocale)
+	issuerOverview := getIssuerDisplay(metadata.LocalizedIssuerDisplays, preferredLocale)
 
 	return &ResolvedDisplayData{
 		IssuerDisplay:      issuerOverview,

--- a/pkg/credentialschema/credentialschema_test.go
+++ b/pkg/credentialschema/credentialschema_test.go
@@ -177,7 +177,7 @@ func TestResolve(t *testing.T) {
 				err = json.Unmarshal(sampleIssuerMetadata, &issuerMetadata)
 				require.NoError(t, err)
 
-				issuerMetadata.IssuerDisplays = nil
+				issuerMetadata.LocalizedIssuerDisplays = nil
 
 				resolvedDisplayData, err := credentialschema.Resolve(
 					credentialschema.WithCredentials([]*verifiable.Credential{credential}),
@@ -387,8 +387,8 @@ func TestResolve(t *testing.T) {
 		require.NoError(t, err)
 
 		issuerMetadata.CredentialsSupported[0].CredentialSubject["sensitive_id"] = issuer.Claim{
-			Displays: []issuer.Display{{}},
-			Mask:     "regex(()",
+			LocalizedClaimDisplays: []issuer.LocalizedClaimDisplay{{}},
+			Mask:                   "regex(()",
 		}
 
 		resolvedDisplayData, errResolve := credentialschema.Resolve(

--- a/pkg/credentialschema/issuerdisplay.go
+++ b/pkg/credentialschema/issuerdisplay.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
 )
 
-func getIssuerDisplay(issuerDisplays []issuer.Display, locale string) *ResolvedIssuerDisplay {
+func getIssuerDisplay(issuerDisplays []issuer.LocalizedIssuerDisplay, locale string) *ResolvedIssuerDisplay {
 	if len(issuerDisplays) == 0 {
 		return nil
 	}

--- a/pkg/models/issuer/metadata.go
+++ b/pkg/models/issuer/metadata.go
@@ -9,29 +9,28 @@ package issuer
 
 // Metadata represents metadata about an issuer as obtained from their .well-known OpenID configuration.
 type Metadata struct {
-	CredentialIssuer     string                `json:"credential_issuer,omitempty"`
-	AuthorizationServer  string                `json:"authorization_server,omitempty"`
-	CredentialEndpoint   string                `json:"credential_endpoint,omitempty"`
-	CredentialsSupported []SupportedCredential `json:"credentials_supported,omitempty"`
-	// IssuerDisplays represents display information for the issuer's name in various locales.
-	IssuerDisplays []Display `json:"display,omitempty"`
+	CredentialIssuer        string                   `json:"credential_issuer,omitempty"`
+	AuthorizationServer     string                   `json:"authorization_server,omitempty"`
+	CredentialEndpoint      string                   `json:"credential_endpoint,omitempty"`
+	CredentialsSupported    []SupportedCredential    `json:"credentials_supported,omitempty"`
+	LocalizedIssuerDisplays []LocalizedIssuerDisplay `json:"display,omitempty"`
 }
 
 // SupportedCredential represents metadata about a credential type that a credential issuer can issue.
 type SupportedCredential struct {
-	Format                               string               `json:"format,omitempty"`
-	Types                                []string             `json:"types,omitempty"`
-	ID                                   string               `json:"id,omitempty"`
-	Overview                             []CredentialOverview `json:"display,omitempty"`
-	CredentialSubject                    map[string]Claim     `json:"credentialSubject,omitempty"`
-	CryptographicBindingMethodsSupported []string             `json:"cryptographic_binding_methods_supported,omitempty"`
-	CryptographicSuitesSupported         []string             `json:"cryptographic_suites_supported,omitempty"`
+	Format                               string                       `json:"format,omitempty"`
+	Types                                []string                     `json:"types,omitempty"`
+	ID                                   string                       `json:"id,omitempty"`
+	LocalizedCredentialDisplays          []LocalizedCredentialDisplay `json:"display,omitempty"`
+	CredentialSubject                    map[string]Claim             `json:"credentialSubject,omitempty"`
+	CryptographicBindingMethodsSupported []string                     `json:"cryptographic_binding_methods_supported,omitempty"` //nolint:lll // Formatter forces these line symbols to line up, and this is a long name
+	CryptographicSuitesSupported         []string                     `json:"cryptographic_suites_supported,omitempty"`
 }
 
-// CredentialOverview represents display data for a credential as a whole.
+// LocalizedCredentialDisplay represents display data for a credential as a whole for a certain locale.
 // Display data for specific claims (e.g. first name, date of birth, etc.) are in SupportedCredential.CredentialSubject
 // (in the parent object above).
-type CredentialOverview struct {
+type LocalizedCredentialDisplay struct {
 	Name            string `json:"name,omitempty"`
 	Locale          string `json:"locale,omitempty"`
 	Logo            *Logo  `json:"logo,omitempty"`
@@ -42,12 +41,11 @@ type CredentialOverview struct {
 // Claim represents display data for a specific claim in (potentially) multiple locales.
 // Each ClaimDisplay represents display data for a single locale.
 type Claim struct {
-	// Displays represents display data for a specific claim in various locales.
-	Displays  []Display `json:"display,omitempty"`
-	ValueType string    `json:"value_type,omitempty"`
-	Order     *int      `json:"order,omitempty"`
-	Pattern   string    `json:"pattern,omitempty"`
-	Mask      string    `json:"mask,omitempty"`
+	LocalizedClaimDisplays []LocalizedClaimDisplay `json:"display,omitempty"`
+	ValueType              string                  `json:"value_type,omitempty"`
+	Order                  *int                    `json:"order,omitempty"`
+	Pattern                string                  `json:"pattern,omitempty"`
+	Mask                   string                  `json:"mask,omitempty"`
 }
 
 // Logo represents display information for a logo.
@@ -56,8 +54,14 @@ type Logo struct {
 	AltText string `json:"alt_text,omitempty"`
 }
 
-// Display represents display information for some piece of data in a specific locale.
-type Display struct {
+// LocalizedIssuerDisplay represents display information for an issuer in a specific locale.
+type LocalizedIssuerDisplay struct {
+	Name   string `json:"name,omitempty"`
+	Locale string `json:"locale,omitempty"`
+}
+
+// LocalizedClaimDisplay represents display information for a claim in a specific locale.
+type LocalizedClaimDisplay struct {
 	Name   string `json:"name,omitempty"`
 	Locale string `json:"locale,omitempty"`
 }

--- a/pkg/openid4ci/issuerinitiatedinteraction.go
+++ b/pkg/openid4ci/issuerinitiatedinteraction.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/trustbloc/wallet-sdk/pkg/models/issuer"
+
 	"github.com/google/uuid"
 	"github.com/hyperledger/aries-framework-go/component/kmscrypto/doc/jose"
 	"github.com/hyperledger/aries-framework-go/component/models/jwt"
@@ -245,6 +247,11 @@ func (i *IssuerInitiatedInteraction) DynamicClientRegistrationSupported() (bool,
 // This method will return an error if the issuer does not support dynamic client registration.
 func (i *IssuerInitiatedInteraction) DynamicClientRegistrationEndpoint() (string, error) {
 	return i.interaction.dynamicClientRegistrationEndpoint()
+}
+
+// IssuerMetadata returns the issuer's metadata.
+func (i *IssuerInitiatedInteraction) IssuerMetadata() (*issuer.Metadata, error) {
+	return i.interaction.getIssuerMetadata()
 }
 
 func (i *IssuerInitiatedInteraction) requestCredentialWithPreAuth(jwtSigner api.JWTSigner,


### PR DESCRIPTION
Breaking changes:
* The new issuerMetadata method takes the existing supportedCredentials method and extends upon it with additional functionality. As such, there's no longer any need for the supportedCredentials method and so it has been removed.
* Some of the field/object names in the Go API were changed to make them more clear.

Note that the claim display data in the issuer metadata object is not exposed via Gomobile currently.