### PR TITLE
feat(sdk): Support for the OAuth Discoverable Client ID Scheme

### DIFF
--- a/cmd/wallet-sdk-gomobile/openid4ci/createauthorizationurlopts.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/createauthorizationurlopts.go
@@ -11,8 +11,9 @@ import "github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
 // CreateAuthorizationURLOpts contains all optional arguments that can be passed into the
 // createAuthorizationURL method.
 type CreateAuthorizationURLOpts struct {
-	scopes      *api.StringArray
-	issuerState *string
+	scopes                             *api.StringArray
+	issuerState                        *string
+	useOAuthDiscoverableClientIDScheme bool
 }
 
 // NewCreateAuthorizationURLOpts returns a new CreateAuthorizationURLOpts object.
@@ -46,6 +47,18 @@ func (c *CreateAuthorizationURLOpts) SetScopes(scopes *api.StringArray) *CreateA
 // this option.
 func (c *CreateAuthorizationURLOpts) SetIssuerState(issuerState string) *CreateAuthorizationURLOpts {
 	c.issuerState = &issuerState
+
+	return c
+}
+
+// UseOAuthDiscoverableClientIDScheme is an option for the CreateAuthorizationURL method that will cause the
+// OAuth Discoverable Client ID scheme to be specified in the authorization URL.
+// See https://mattrglobal.github.io/draft-looker-oauth-client-id-scheme/draft-looker-oauth-client-id-scheme.html
+// for more information on the requirements of this scheme. Note that successful usage of this scheme requires the
+// issuer to support it and for the client to meet the scheme's pre-requisites. Be sure to also set your client ID
+// appropriately as required by the scheme.
+func (c *CreateAuthorizationURLOpts) UseOAuthDiscoverableClientIDScheme() *CreateAuthorizationURLOpts {
+	c.useOAuthDiscoverableClientIDScheme = true
 
 	return c
 }

--- a/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/interaction.go
@@ -1,0 +1,111 @@
+/*
+Copyright Gen Digital Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package openid4ci
+
+// This file contains code that's common to both the IssuerInitiatedInteraction and WalletInitiatedInteraction types.
+
+import (
+	"errors"
+
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/api"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/verifiable"
+	"github.com/trustbloc/wallet-sdk/cmd/wallet-sdk-gomobile/wrapper"
+	goapi "github.com/trustbloc/wallet-sdk/pkg/api"
+	"github.com/trustbloc/wallet-sdk/pkg/common"
+	openid4cigoapi "github.com/trustbloc/wallet-sdk/pkg/openid4ci"
+	"github.com/trustbloc/wallet-sdk/pkg/walleterror"
+
+	afgoverifiable "github.com/hyperledger/aries-framework-go/component/models/verifiable"
+	"github.com/hyperledger/aries-framework-go/component/storageutil/mem"
+)
+
+func createGoAPIClientConfig(didResolver api.DIDResolver, opts *InteractionOpts) (*openid4cigoapi.ClientConfig, error) {
+	activityLogger := createGoAPIActivityLogger(opts.activityLogger)
+
+	httpClient := wrapper.NewHTTPClient(opts.httpTimeout, opts.additionalHeaders, opts.disableHTTPClientTLSVerification)
+
+	goAPIClientConfig := &openid4cigoapi.ClientConfig{
+		DIDResolver:                      &wrapper.VDRResolverWrapper{DIDResolver: didResolver},
+		ActivityLogger:                   activityLogger,
+		MetricsLogger:                    &wrapper.MobileMetricsLoggerWrapper{MobileAPIMetricsLogger: opts.metricsLogger},
+		DisableVCProofChecks:             opts.disableVCProofChecks,
+		NetworkDocumentLoaderHTTPTimeout: opts.httpTimeout,
+		HTTPClient:                       httpClient,
+	}
+
+	if opts.documentLoader != nil {
+		documentLoaderWrapper := &wrapper.DocumentLoaderWrapper{
+			DocumentLoader: opts.documentLoader,
+		}
+
+		goAPIClientConfig.DocumentLoader = documentLoaderWrapper
+	} else {
+		dlHTTPClient := wrapper.NewHTTPClient(opts.httpTimeout, api.Headers{}, opts.disableHTTPClientTLSVerification)
+
+		var err error
+		goAPIClientConfig.DocumentLoader, err = common.CreateJSONLDDocumentLoader(dlHTTPClient, mem.NewProvider())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return goAPIClientConfig, nil
+}
+
+func createGoAPIActivityLogger(mobileAPIActivityLogger api.ActivityLogger) goapi.ActivityLogger {
+	if mobileAPIActivityLogger == nil {
+		return nil // Will result in activity logging being disabled in the OpenID4CI IssuerInitiatedInteraction object.
+	}
+
+	return &wrapper.MobileActivityLoggerWrapper{MobileAPIActivityLogger: mobileAPIActivityLogger}
+}
+
+func convertToGoAPICreateAuthURLOpts(opts *CreateAuthorizationURLOpts) []openid4cigoapi.CreateAuthorizationURLOpt {
+	if opts == nil {
+		opts = NewCreateAuthorizationURLOpts()
+	}
+
+	if opts.scopes == nil {
+		opts.scopes = api.NewStringArray()
+	}
+
+	goAPIOpts := []openid4cigoapi.CreateAuthorizationURLOpt{openid4cigoapi.WithScopes(opts.scopes.Strings)}
+
+	if opts.issuerState != nil {
+		goAPIOpts = append(goAPIOpts, openid4cigoapi.WithIssuerState(*opts.issuerState))
+	}
+
+	if opts.useOAuthDiscoverableClientIDScheme {
+		goAPIOpts = append(goAPIOpts, openid4cigoapi.WithOAuthDiscoverableClientIDScheme())
+	}
+
+	return goAPIOpts
+}
+
+func createSigner(vm *api.VerificationMethod, crypto api.Crypto) (*common.JWSSigner, error) {
+	if vm == nil {
+		return nil, walleterror.NewInvalidSDKUsageError(openid4cigoapi.ErrorModule,
+			errors.New("verification method must be provided"))
+	}
+
+	signer, err := common.NewJWSSigner(vm.ToSDKVerificationMethod(), crypto)
+	if err != nil {
+		return nil, err
+	}
+
+	return signer, nil
+}
+
+func toGomobileCredentials(credentials []*afgoverifiable.Credential) *verifiable.CredentialsArray {
+	gomobileCredentials := verifiable.NewCredentialsArray()
+
+	for i := range credentials {
+		gomobileCredentials.Add(verifiable.NewCredential(credentials[i]))
+	}
+
+	return gomobileCredentials
+}

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction_test.go
@@ -188,7 +188,9 @@ func TestIssuerInitiatedInteraction_CreateAuthorizationURL(t *testing.T) {
 			createCredentialOfferIssuanceURI(t, "example.com", false),
 			nil, false)
 
-		authorizationLink, err := interaction.CreateAuthorizationURL("clientID", "redirectURI", nil)
+		opts := openid4ci.NewCreateAuthorizationURLOpts().UseOAuthDiscoverableClientIDScheme()
+
+		authorizationLink, err := interaction.CreateAuthorizationURL("clientID", "redirectURI", opts)
 		requireErrorContains(t, err, "INVALID_SDK_USAGE")
 		requireErrorContains(t, err, "issuer does not support the authorization code grant type")
 		require.Empty(t, authorizationLink)

--- a/pkg/openid4ci/createauthorizationurlopts.go
+++ b/pkg/openid4ci/createauthorizationurlopts.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package openid4ci
 
 type createAuthorizationURLOpts struct {
-	scopes      []string
-	issuerState *string
+	scopes                             []string
+	issuerState                        *string
+	useOAuthDiscoverableClientIDScheme bool
 }
 
 // CreateAuthorizationURLOpt is an option for the CreateAuthorizationURL method.
@@ -40,6 +41,18 @@ func WithScopes(scopes []string) CreateAuthorizationURLOpt {
 func WithIssuerState(issuerState string) CreateAuthorizationURLOpt {
 	return func(opts *createAuthorizationURLOpts) {
 		opts.issuerState = &issuerState
+	}
+}
+
+// WithOAuthDiscoverableClientIDScheme is an option for the CreateAuthorizationURL method that will cause the
+// OAuth Discoverable Client ID scheme to be specified in the authorization URL.
+// See https://mattrglobal.github.io/draft-looker-oauth-client-id-scheme/draft-looker-oauth-client-id-scheme.html
+// for more information on the requirements of this scheme. Note that successful usage of this scheme requires the
+// issuer to support it and for the client to meet the scheme's pre-requisites. Be sure to also set your client ID
+// appropriately as required by the scheme.
+func WithOAuthDiscoverableClientIDScheme() CreateAuthorizationURLOpt {
+	return func(opts *createAuthorizationURLOpts) {
+		opts.useOAuthDiscoverableClientIDScheme = true
 	}
 }
 

--- a/pkg/openid4ci/interaction.go
+++ b/pkg/openid4ci/interaction.go
@@ -59,7 +59,7 @@ type interaction struct {
 // Check the issuer's capabilities first using the Capabilities method.
 // If scopes are needed, pass them in using the WithScopes option.
 func (i *interaction) createAuthorizationURL(clientID, redirectURI, format string, types []string, issuerState *string,
-	scopes []string,
+	scopes []string, useOAuthDiscoverableClientIDScheme bool,
 ) (string, error) {
 	err := i.populateIssuerMetadata()
 	if err != nil {
@@ -78,7 +78,7 @@ func (i *interaction) createAuthorizationURL(clientID, redirectURI, format strin
 		return "", err
 	}
 
-	authCodeOptions := i.generateAuthCodeOptions(authorizationDetails, issuerState)
+	authCodeOptions := i.generateAuthCodeOptions(authorizationDetails, issuerState, useOAuthDiscoverableClientIDScheme)
 
 	i.authCodeURLState = uuid.New().String()
 
@@ -138,7 +138,7 @@ func (i *interaction) generateAuthorizationDetails(format string, types []string
 }
 
 func (i *interaction) generateAuthCodeOptions(authorizationDetails []byte,
-	issuerState *string,
+	issuerState *string, useOAuthDiscoverableClientIDScheme bool,
 ) []oauth2.AuthCodeOption {
 	authCodeOptions := []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("code_challenge", i.generateCodeChallenge()),
@@ -148,6 +148,11 @@ func (i *interaction) generateAuthCodeOptions(authorizationDetails []byte,
 
 	if issuerState != nil {
 		authCodeOptions = append(authCodeOptions, oauth2.SetAuthURLParam("issuer_state", *issuerState))
+	}
+
+	if useOAuthDiscoverableClientIDScheme {
+		authCodeOptions = append(authCodeOptions, oauth2.SetAuthURLParam("client_id_scheme",
+			"urn:ietf:params:oauth:client-id-scheme:oauth-discoverable-client"))
 	}
 
 	return authCodeOptions

--- a/pkg/openid4ci/issuerinitiatedinteraction.go
+++ b/pkg/openid4ci/issuerinitiatedinteraction.go
@@ -141,7 +141,7 @@ func (i *IssuerInitiatedInteraction) CreateAuthorizationURL(clientID, redirectUR
 	}
 
 	return i.interaction.createAuthorizationURL(clientID, redirectURI, i.credentialFormats[0], i.credentialTypes[0],
-		issuerState, processedOpts.scopes)
+		issuerState, processedOpts.scopes, processedOpts.useOAuthDiscoverableClientIDScheme)
 }
 
 // RequestCredentialWithPreAuth requests credential(s) from the issuer. This method can only be used for the

--- a/pkg/openid4ci/issuerinitiatedinteraction_test.go
+++ b/pkg/openid4ci/issuerinitiatedinteraction_test.go
@@ -362,14 +362,27 @@ func TestIssuerInitiatedInteraction_CreateAuthorizationURL(t *testing.T) {
 			`"authorization_server":"%s"}`,
 			server.URL, authorizationServerURL)
 
-		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
+		t.Run("Not using any options", func(t *testing.T) {
+			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
 
-		authorizationURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
-		require.NoError(t, err)
-		require.Contains(t, authorizationURL, authorizationServerURL+
-			"?authorization_details=%7B%22type%22%3A%22openid_credential%22%2C%22locations"+
-			"%22%3A%5B%22%22%5D%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22VerifiedEmployee%22%5D%2C%22"+
-			"format%22%3A%22jwt_vc_json%22%7D&client_id=clientID")
+			authorizationURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI")
+			require.NoError(t, err)
+			require.Contains(t, authorizationURL, authorizationServerURL+
+				"?authorization_details=%7B%22type%22%3A%22openid_credential%22%2C%22locations"+
+				"%22%3A%5B%22%22%5D%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22VerifiedEmployee%22%5D%2C%22"+
+				"format%22%3A%22jwt_vc_json%22%7D&client_id=clientID")
+		})
+		t.Run("Using the OAuth Discoverable Client ID Scheme", func(t *testing.T) {
+			interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, server.URL, true, true))
+
+			authorizationURL, err := interaction.CreateAuthorizationURL("clientID", "redirectURI",
+				openid4ci.WithOAuthDiscoverableClientIDScheme())
+			require.NoError(t, err)
+			require.Contains(t, authorizationURL, authorizationServerURL+
+				"?authorization_details=%7B%22type%22%3A%22openid_credential%22%2C%22locations"+
+				"%22%3A%5B%22%22%5D%2C%22types%22%3A%5B%22VerifiableCredential%22%2C%22VerifiedEmployee%22%5D%2C%22"+
+				"format%22%3A%22jwt_vc_json%22%7D&client_id=clientID")
+		})
 	})
 	t.Run("Fail to get issuer metadata", func(t *testing.T) {
 		interaction := newIssuerInitiatedInteraction(t, createCredentialOfferIssuanceURI(t, "example.com", true, true))

--- a/pkg/openid4ci/walletinitiatedinteraction.go
+++ b/pkg/openid4ci/walletinitiatedinteraction.go
@@ -95,7 +95,7 @@ func (i *WalletInitiatedInteraction) CreateAuthorizationURL(clientID, redirectUR
 	processedOpts := processCreateAuthorizationURLOpts(opts)
 
 	authorizationURL, err := i.interaction.createAuthorizationURL(clientID, redirectURI, credentialFormat,
-		credentialTypes, processedOpts.issuerState, processedOpts.scopes)
+		credentialTypes, processedOpts.issuerState, processedOpts.scopes, processedOpts.useOAuthDiscoverableClientIDScheme)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
* Support for the OAuth Discoverable Client ID Scheme described in https://mattrglobal.github.io/draft-looker-oauth-client-id-scheme/draft-looker-oauth-client-id-scheme.html.
* Added documentation for how to use this scheme with Wallet-SDK.
* Updated documentation for the other methods of getting/providing a client ID.
* Eliminated some code duplication by doing some refactoring.