### PR TITLE
docs(sdk): Remove "last updated" lines

### DIFF
--- a/cmd/wallet-sdk-gomobile/docs/packages.md
+++ b/cmd/wallet-sdk-gomobile/docs/packages.md
@@ -1,7 +1,5 @@
 # Packages
 
-Last updated: March 13, 2023 (commit `57cea0315411332c6af691ee2a90bc362694a1a5`)
-
 The way you use the SDK differs between Android and iOS. This comes down to differences in how the `gomobile` tool
 generates the bindings for the two platforms. Due to these differences (and the limitations of `gomobile`),
 it's difficult to pick names that look perfect across both platforms and the Go source code.

--- a/cmd/wallet-sdk-gomobile/docs/usage.md
+++ b/cmd/wallet-sdk-gomobile/docs/usage.md
@@ -1,7 +1,5 @@
 # SDK Usage
 
-Last updated: April 11, 2023 (commit `f2fb58089f254110339ff2605374966660e8063c`)
-
 This guide explains how to use this SDK in Android or iOS code. The examples in this document demonstrate
 how to use the various APIs from a Kotlin and Swift perspective.
 

--- a/cmd/wallet-sdk-js/docs/usage.md
+++ b/cmd/wallet-sdk-js/docs/usage.md
@@ -1,7 +1,5 @@
 # JS SDK Usage
 
-Last updated: Jul 18, 2023 (commit `0f0e847a345a979d216f1e03313a00b630e7678e`)
-
 This guide explains how to use this SDK in Web. The examples in this document demonstrate
 how to use the various APIs from a JavaScript perspective.
 


### PR DESCRIPTION
The docs have a "last updated" line containing the date and commit hash of their last update. There are a few problems with this:
* It's virtually impossible to specify the hash of the commit you're working on, since the commit hash relies on the content of your commit. Therefore the best you can do is list a previous commit hash. If you wanted to add docs for some new code you added, then you'd have to commit the code first (to get the hash), and then add the docs afterward, which is inconvenient.
* It's easy to forget to update the date and hard to guarantee the date will match when the pull request actually gets merged in.

For these reasons, and since Git can already tell you the last commit that a file was modified in anyway, it makes sense to simply remove these lines.