### PR TITLE
fix(sdk): Update linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,6 +91,7 @@ linters:
     - ireturn # Required by aries-framework-go, a library we use
     - tagliatelle # JSON tags using camel-case required by the specs we implement
     - varnamelen # This linter prevents us from using "i" as an index variable or "vc" for a variable name for a Verifiable Credential, both of which are very common in our code
+    - depguard # TODO consider enabling in the future
 
 issues:
   exclude-use-default: false

--- a/cmd/wallet-sdk-gomobile/localkms/localkms.go
+++ b/cmd/wallet-sdk-gomobile/localkms/localkms.go
@@ -123,6 +123,6 @@ func (k *kmsStoreWrapper) Get(keysetID string) ([]byte, error) {
 
 // Delete isn't used since we don't expose the Rotate method from the underlying Aries local KMS.
 // This method is just here as it's required to satisfy the Aries KMS store interface.
-func (k *kmsStoreWrapper) Delete(keysetID string) error {
+func (k *kmsStoreWrapper) Delete(string) error {
 	return nil
 }

--- a/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/issuerinitiatedinteraction.go
@@ -127,7 +127,8 @@ func (i *IssuerInitiatedInteraction) RequestCredentialWithPreAuth(
 // The redirect URI that you pass in here should look like the redirect URI that you passed in to the
 // CreateAuthorizationURL, except that now it has some URL query parameters appended to it.
 func (i *IssuerInitiatedInteraction) RequestCredentialWithAuth(vm *api.VerificationMethod,
-	redirectURIWithAuthCode string, opts *RequestCredentialWithAuthOpts,
+	redirectURIWithAuthCode string,
+	opts *RequestCredentialWithAuthOpts, //nolint: revive // The opts param is reserved for future use.
 ) (*verifiable.CredentialsArray, error) {
 	signer, err := createSigner(vm, i.crypto)
 	if err != nil {

--- a/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction.go
+++ b/cmd/wallet-sdk-gomobile/openid4ci/walletinitiatedinteraction.go
@@ -121,7 +121,8 @@ func (i *WalletInitiatedInteraction) CreateAuthorizationURL(clientID, redirectUR
 // The redirect URI that you pass in here should look like the redirect URI that you passed in to the
 // CreateAuthorizationURL, except that now it has some URL query parameters appended to it.
 func (i *WalletInitiatedInteraction) RequestCredential(vm *api.VerificationMethod,
-	redirectURIWithAuthCode string, opts *RequestCredentialWithAuthOpts,
+	redirectURIWithAuthCode string,
+	opts *RequestCredentialWithAuthOpts, //nolint: revive // The opts param is reserved for future use.
 ) (*verifiable.CredentialsArray, error) {
 	signer, err := createSigner(vm, i.crypto)
 	if err != nil {

--- a/cmd/wallet-sdk-gomobile/openid4vp/interaction_test.go
+++ b/cmd/wallet-sdk-gomobile/openid4vp/interaction_test.go
@@ -228,7 +228,7 @@ func (c *mockCrypto) Sign(_ []byte, _ string) ([]byte, error) {
 	return c.SignResult, c.SignErr
 }
 
-func (c *mockCrypto) Verify(signature, msg []byte, keyID string) error {
+func (c *mockCrypto) Verify([]byte, []byte, string) error {
 	return c.VerifyErr
 }
 

--- a/cmd/wallet-sdk-gomobile/verifiable/parsecredential_test.go
+++ b/cmd/wallet-sdk-gomobile/verifiable/parsecredential_test.go
@@ -51,6 +51,6 @@ type documentLoaderMock struct {
 	LoadErr    error
 }
 
-func (d *documentLoaderMock) LoadDocument(u string) (*api.LDDocument, error) {
+func (d *documentLoaderMock) LoadDocument(string) (*api.LDDocument, error) {
 	return d.LoadResult, d.LoadErr
 }

--- a/cmd/wallet-sdk-gomobile/wrapper/httpclient_test.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/httpclient_test.go
@@ -23,7 +23,7 @@ type mockServer struct {
 	headersToCheck *api.Headers
 }
 
-func (m *mockServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+func (m *mockServer) ServeHTTP(_ http.ResponseWriter, request *http.Request) {
 	if m.headersToCheck != nil {
 		for _, headerToCheck := range m.headersToCheck.GetAll() {
 			// Note: for these tests, we're assuming that there aren't multiple values under a single name/key.

--- a/cmd/wallet-sdk-gomobile/wrapper/resolverwrapper_test.go
+++ b/cmd/wallet-sdk-gomobile/wrapper/resolverwrapper_test.go
@@ -54,6 +54,6 @@ type mocksDIDResolver struct {
 	ResolveErr      error
 }
 
-func (m *mocksDIDResolver) Resolve(did string) ([]byte, error) {
+func (m *mocksDIDResolver) Resolve(string) ([]byte, error) {
 	return m.ResolveDocBytes, m.ResolveErr
 }

--- a/pkg/common/jwt_signer_test.go
+++ b/pkg/common/jwt_signer_test.go
@@ -205,11 +205,11 @@ type cryptoMock struct {
 	Err       error
 }
 
-func (c *cryptoMock) Sign(msg []byte, keyID string) ([]byte, error) {
+func (c *cryptoMock) Sign([]byte, string) ([]byte, error) {
 	return c.Signature, c.Err
 }
 
 // Verify is not yet defined.
-func (c *cryptoMock) Verify(signature, msg []byte, keyID string) error {
+func (c *cryptoMock) Verify([]byte, []byte, string) error {
 	return nil
 }

--- a/pkg/credentialquery/credentialquery_test.go
+++ b/pkg/credentialquery/credentialquery_test.go
@@ -122,7 +122,7 @@ type readerMock struct {
 	err         error
 }
 
-func (r *readerMock) Get(id string) (*verifiable.Credential, error) {
+func (r *readerMock) Get(string) (*verifiable.Credential, error) {
 	return nil, r.err
 }
 

--- a/pkg/internal/mock/httpclient.go
+++ b/pkg/internal/mock/httpclient.go
@@ -44,6 +44,6 @@ func (c *HTTPClientMock) Do(req *http.Request) (*http.Response, error) {
 
 	return &http.Response{
 		StatusCode: c.StatusCode,
-		Body:       io.NopCloser(bytes.NewBuffer([]byte(c.Response))),
+		Body:       io.NopCloser(bytes.NewBufferString(c.Response)),
 	}, nil
 }

--- a/pkg/openid4ci/issuerinitiatedinteraction_test.go
+++ b/pkg/openid4ci/issuerinitiatedinteraction_test.go
@@ -1587,7 +1587,7 @@ func (s *jwtSignerMock) GetKeyID() string {
 	return s.keyID
 }
 
-func (s *jwtSignerMock) Sign(data []byte) ([]byte, error) {
+func (s *jwtSignerMock) Sign([]byte) ([]byte, error) {
 	return []byte("test signature"), s.Err
 }
 

--- a/pkg/openid4vp/openid4vp.go
+++ b/pkg/openid4vp/openid4vp.go
@@ -207,7 +207,7 @@ func (o *Interaction) presentCredentials(credentials []*verifiable.Credential, o
 func (o *Interaction) sendAuthorizedResponse(responseBody string) error {
 	_, err := httprequest.New(o.httpClient, o.metricsLogger).Do(http.MethodPost,
 		o.requestObject.RedirectURI, "application/x-www-form-urlencoded",
-		bytes.NewBuffer([]byte(responseBody)),
+		bytes.NewBufferString(responseBody),
 		fmt.Sprintf(sendAuthorizedResponseEventText, o.requestObject.RedirectURI),
 		presentCredentialEventText, processAuthorizationErrorResponse)
 
@@ -548,7 +548,7 @@ type resolverAdapter struct {
 	didResolver api.DIDResolver
 }
 
-func (r *resolverAdapter) Resolve(did string, opts ...vdrspi.DIDMethodOption) (*diddoc.DocResolution, error) {
+func (r *resolverAdapter) Resolve(did string, _ ...vdrspi.DIDMethodOption) (*diddoc.DocResolution, error) {
 	return r.didResolver.Resolve(did)
 }
 

--- a/pkg/openid4vp/openid4vp_test.go
+++ b/pkg/openid4vp/openid4vp_test.go
@@ -726,7 +726,7 @@ type jwtSignatureVerifierMock struct {
 	err error
 }
 
-func (s *jwtSignatureVerifierMock) Verify(joseHeaders jose.Headers, payload, signingInput, signature []byte) error {
+func (s *jwtSignatureVerifierMock) Verify(jose.Headers, []byte, []byte, []byte) error {
 	return s.err
 }
 

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -10,7 +10,7 @@ set -e
 echo "Running $0"
 
 DOCKER_CMD=${DOCKER_CMD:-docker}
-GOLANGCI_LINT_IMAGE="golangci/golangci-lint:v1.50.1"
+GOLANGCI_LINT_IMAGE="golangci/golangci-lint:v1.53.3"
 
 if [ ! $(command -v ${DOCKER_CMD}) ]; then
     exit 0


### PR DESCRIPTION
Some new dependencies from aries-framework-go that we will need have some incompatibilities with the older linter version we're using. Updating the linter fixes this. This commit also updates code to comply with new rules in the linter (except for depguard, which has been added to the list of exceptions for now as it requires more consideration).