### PR TITLE
feat(app): Detect type of supported schemas when credentials are not found

### DIFF
--- a/demo/app/ios/Runner/flutterPlugin.swift
+++ b/demo/app/ios/Runner/flutterPlugin.swift
@@ -175,6 +175,26 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
                 var resp = convertVerifiableCredentialsArray(arr: matchedReq.atIndex(0)!.descriptor(at:0)!.matchedVCs!)
                 if (resp.isEmpty) {
                     var typeConstraint = matchedReq.atIndex(0)!.descriptor(at:0)!.typeConstraint()
+                    if typeConstraint == "" {
+                      var schemas =  matchedReq.atIndex(0)!.descriptor(at:0)!.schemas()
+                        var schemaList:[Any] = []
+                        if let schemas = schemas {
+                            var schemasResp : [String: Any] = [:]
+                            for index in 0..<schemas.length() {
+                                if let schema = schemas.atIndex(index) {
+                                    schemasResp["required"] = schema.required()
+                                    schemasResp["uri"] = schema.uri()
+                                }
+                                
+                                schemaList.append(schemasResp)
+                            }
+                            
+                            return result(FlutterError.init(code: "NATIVE_ERR",
+                                                            message: "No credentials conforming to the following schemas were found",
+                                                            details: "\(schemaList)"))
+                            
+                        }
+                    }
                     return result(FlutterError.init(code: "NATIVE_ERR",
                                                     message: "No credentials of type \(typeConstraint) were found",
                                                     details: "Required credential \(typeConstraint) is missing from the wallet"))

--- a/demo/app/lib/scenarios/handle_openid_vp_flow.dart
+++ b/demo/app/lib/scenarios/handle_openid_vp_flow.dart
@@ -30,7 +30,7 @@ void handleOpenIDVpFlow(BuildContext context, String qrCodeURL) async {
   storedCredentials = await storageService.retrieveCredentials(username!);
   log("stored credentials -> $storedCredentials");
 
-  credentials = storedCredentials.map((e) => e.value.rawCredential).toList();
+ credentials = storedCredentials.map((e) => e.value.rawCredential).toList();
   if (credentials.isEmpty) {
     log("credentials is empty now $credentials");
     Navigator.push(
@@ -43,7 +43,7 @@ void handleOpenIDVpFlow(BuildContext context, String qrCodeURL) async {
   }
 
   try {
-    var resp = await walletSDKPlugin.processAuthorizationRequest(
+     await walletSDKPlugin.processAuthorizationRequest(
         authorizationRequest: qrCodeURL, storedCredentials: credentials);
   } on PlatformException catch (error) {
     Navigator.push(


### PR DESCRIPTION

<img src="https://github.com/trustbloc/wallet-sdk/assets/7862595/545da397-291a-4932-8c7d-15aabc7620a9" width="200" height="400" />

Edge case for when both type and schemas are missing will be addresses in  #575 


Signed-off-by: Talwinder kaur <talwinder.kaur@avast.com>