### PR TITLE
fix(app): Add exception handling for the QR code scanning process

### DIFF
--- a/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/flutter/app/MainActivity.kt
@@ -77,7 +77,7 @@ class MainActivity : FlutterActivity() {
                             val err = Walleterror.parse(e.message)
                             result.error(
                                 "Exception",
-                                "Error while authorizing the oidc vc flow",
+                                "Error while initializing the interaction",
                                 "code: ${err.code}, error: ${err.category}, details: ${err.details}"
                             )
 

--- a/demo/app/ios/Runner/WalletSDK.swift
+++ b/demo/app/ios/Runner/WalletSDK.swift
@@ -49,8 +49,9 @@ class WalletSDK {
         }
         
         activityLogger = MemNewActivityLogger()
- 
-        return OpenID4CI(requestURI: requestURI, didResolver: didResolver, crypto: crypto, activityLogger: activityLogger! )
+        
+        
+        return try OpenID4CI(requestURI: requestURI, didResolver: didResolver, crypto: crypto, activityLogger: activityLogger! )
     }
     
     func createOpenID4CIWalletInitiatedInteraction(issuerURI: String) throws -> WalletInitiatedOpenID4CI {

--- a/demo/app/ios/Runner/flutterPlugin.swift
+++ b/demo/app/ios/Runner/flutterPlugin.swift
@@ -320,10 +320,10 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
             docResolution["did"] = doc.id_(nil)
             docResolution["didDoc"] = doc.content
             result(docResolution)
-        } catch {
+        } catch let error as NSError {
             result(FlutterError.init(code: "NATIVE_ERR",
                                      message: "error while creating did",
-                                     details: error))
+                                     details: error.localizedDescription))
         }
     }
     
@@ -418,10 +418,10 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
             
             result(flowTypeData)
             
-          } catch {
-              result(FlutterError.init(code: "NATIVE_ERR",
+          } catch let error as NSError {
+              result(FlutterError.init(code: "Exception",
                                        message: "error while initializing issuance flow",
-                                       details: error))
+                                       details: error.localizedDescription))
           }
     }
     
@@ -470,10 +470,10 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
             
             result(issuerMetaDataRespList)
             
-        } catch {
+        } catch let error as NSError {
             result(FlutterError.init(code: "NATIVE_ERR",
                                      message: "error while getting issuer meta data",
-                                     details: error))
+                                     details: error.localizedDescription))
         }
         
     }
@@ -602,10 +602,10 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
             let authorizationURL = try walletInitiatedOpenID4CI.createAuthorizationURLWalletInitiatedFlow(scopes: scopes, credentialFormat: credentialFormat, credentialTypes: credentialTypes, clientID: clientID, redirectURI: redirectURI, issuerURI: issuerURI)
             
              result(authorizationURL)
-        } catch {
+        } catch let error as NSError {
             result(FlutterError.init(code: "NATIVE_ERR",
                                      message: "error while creating authorization URL in wallet initiated issuance flow",
-                                     details: error))
+                                     details: error.localizedDescription))
         }
     }
     
@@ -626,10 +626,10 @@ public class SwiftWalletSDKPlugin: NSObject, FlutterPlugin {
 
            result(verifierDisplayData)
     
-        } catch {
+        } catch let error as NSError {
         result(FlutterError.init(code: "NATIVE_ERR",
                                  message: "error while getting verifier display data",
-                                 details: error))
+                                 details: error.localizedDescription))
        }
         
     }

--- a/demo/app/lib/scenarios/handle_openid_issuance_flow.dart
+++ b/demo/app/lib/scenarios/handle_openid_issuance_flow.dart
@@ -13,6 +13,8 @@ import 'package:flutter/services.dart';
 import 'package:app/models/credential_offer.dart';
 import 'package:http/http.dart' as http;
 
+import '../views/custom_error.dart';
+
 void handleOpenIDIssuanceFlow(BuildContext context, String qrCodeURL) async {
   var WalletSDKPlugin = WalletSDK();
   var authCodeArgs;
@@ -31,8 +33,21 @@ void handleOpenIDIssuanceFlow(BuildContext context, String qrCodeURL) async {
       };
     }
   }
-
-  var flowTypeData = await WalletSDKPlugin.initialize(qrCodeURL, authCodeArgs);
+  log("qr code url -  $qrCodeURL");
+  var flowTypeData;
+  try {
+    flowTypeData = await WalletSDKPlugin.initialize(qrCodeURL, authCodeArgs);
+  } catch (error) {
+    var errString = error.toString().replaceAll(r'\', '');
+    Navigator.push(
+        context,
+        MaterialPageRoute(
+            builder: (context) => CustomError(
+                 titleBarString: "QR Code Scanned",
+                requestErrorTitleMsg: "error while intializing the interaction",
+                requestErrorSubTitleMsg: "${errString}")));
+    return;
+  }
   var flowTypeDataEncoded = json.encode(flowTypeData);
   Map<String, dynamic> responseJson = json.decode(flowTypeDataEncoded);
   var authorizeResultPinRequired = responseJson["pinRequired"];

--- a/demo/app/lib/views/custom_error.dart
+++ b/demo/app/lib/views/custom_error.dart
@@ -5,10 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:app/widgets/common_title_appbar.dart';
 
 class CustomError extends StatefulWidget {
+  String? titleBarString;
   final String requestErrorTitleMsg;
   final String requestErrorSubTitleMsg ;
 
-  const CustomError({super.key, required this.requestErrorTitleMsg, required this.requestErrorSubTitleMsg});
+  CustomError({super.key, required this.requestErrorTitleMsg, required this.requestErrorSubTitleMsg, this.titleBarString});
 
   @override
   State<CustomError> createState() => CustomErrorPage();
@@ -18,7 +19,7 @@ class CustomErrorPage extends State<CustomError> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: const CustomTitleAppBar(pageTitle: '', addCloseIcon: true, height: 60),
+      appBar: CustomTitleAppBar(pageTitle: widget.titleBarString, addCloseIcon: true, height: 60),
      body: Center(
       child: Container (
         padding: const EdgeInsets.all(12),


### PR DESCRIPTION
<img src="https://github.com/trustbloc/wallet-sdk/assets/7862595/8ff2dfe6-0a3a-4118-9970-5f9c8da189ce" width="200" height="400" />

If you enter any random string in the qr code scanning text field in the simulator, that is handled now as well. 

Signed-off-by: Talwinder kaur <talwinder.kaur@avast.com>

