### PR TITLE
refactor(app): Use new DID creation patterns; updated docs

### DIFF
--- a/cmd/wallet-sdk-gomobile/api/api.go
+++ b/cmd/wallet-sdk-gomobile/api/api.go
@@ -10,6 +10,7 @@ package api
 
 // KeyWriter represents a type that is capable of performing operations related to key creation and storage within
 // an underlying KMS.
+// Deprecated: Not needed with the new DID creation pattern. This interface will be removed in a future version.
 type KeyWriter interface {
 	// Create creates a keyset of the given keyType and then writes it to storage.
 	// The public key JWK of the newly generated keyset is returned via the JSONWebKey object.
@@ -17,6 +18,7 @@ type KeyWriter interface {
 }
 
 // KeyReader represents a type that is capable of performing operations related to reading keys from an underlying KMS.
+// Deprecated: Not needed with the new DID creation pattern. This interface will be removed in a future version.
 type KeyReader interface {
 	// ExportPubKey returns the public key associated with the given keyID as a JWK object.
 	ExportPubKey(keyID string) (*JSONWebKey, error)

--- a/cmd/wallet-sdk-gomobile/docs/bestpractices.md
+++ b/cmd/wallet-sdk-gomobile/docs/bestpractices.md
@@ -3,7 +3,8 @@
 This document outlines some best practices for using the mobile bindings.
 
 For information on best practices for higher-level concepts that appear in Wallet-SDK,
-see [here](../docs/bestpractices.md). This document is only applicable to the mobile bindings specifically.
+see [here](../docs/bestpractices.md). While this document is only applicable to the mobile bindings specifically,
+those higher-level best practices that are applicable here as well since they're common to all Wallet-SDK bindings.
 
 ## Using Serializable Objects
 

--- a/cmd/wallet-sdk-gomobile/localkms/localkms.go
+++ b/cmd/wallet-sdk-gomobile/localkms/localkms.go
@@ -24,7 +24,7 @@ const (
 	// KeyTypeED25519 is the name recognized by the Create method for creating an ED25519 keyset.
 	KeyTypeED25519 = kmsspi.ED25519
 	// KeyTypeP256 is the name recognized by the Create method for creating a P-256 keyset.
-	KeyTypeP256 = kmsspi.ECDSAP256TypeIEEEP1363
+	KeyTypeP256 = kmsspi.ECDSAP256IEEEP1363
 	// KeyTypeP384 is the name recognized by the Create method for creating a P-384 keyset.
 	KeyTypeP384 = kmsspi.ECDSAP384IEEEP1363
 )

--- a/cmd/wallet-sdk-js/jsinterop/agent.go
+++ b/cmd/wallet-sdk-js/jsinterop/agent.go
@@ -93,12 +93,7 @@ func createDID(_ js.Value, args []js.Value) (any, error) {
 		return nil, err
 	}
 
-	verificationType, err := jssupport.EnsureString(jssupport.GetOptionalNamedArgument(args, "verificationType"))
-	if err != nil {
-		return nil, err
-	}
-
-	didDoc, err := agentInstance.CreateDID(didMethod, arieskms.KeyType(keyType), verificationType)
+	didDoc, err := agentInstance.CreateDID(didMethod, arieskms.KeyType(keyType))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/wallet-sdk-js/src/index.js
+++ b/cmd/wallet-sdk-js/src/index.js
@@ -22,8 +22,7 @@ export default class Agent {
     async createDID(opts) {
         return await this.goAgent.createDID({
             didMethod: opts.didMethod,
-            keyType: opts.keyType,
-            verificationType: opts.verificationType
+            keyType: opts.keyType
         });
     };
 

--- a/demo/app/android/app/src/androidTest/kotlin/integration_test.kt
+++ b/demo/app/android/app/src/androidTest/kotlin/integration_test.kt
@@ -1,17 +1,14 @@
 import android.content.Context
-import android.net.Uri
-import android.util.Log
 import androidx.test.filters.SmallTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import dev.trustbloc.wallet.BuildConfig
-import dev.trustbloc.wallet.sdk.api.KeyWriter
 import dev.trustbloc.wallet.sdk.api.StringArray
 import dev.trustbloc.wallet.sdk.verifiable.CredentialsArray
 import dev.trustbloc.wallet.sdk.credential.Inquirer
-import dev.trustbloc.wallet.sdk.did.Creator
 import dev.trustbloc.wallet.sdk.did.Resolver
 import dev.trustbloc.wallet.sdk.did.ResolverOpts
+import dev.trustbloc.wallet.sdk.didion.Didion
 import dev.trustbloc.wallet.sdk.localkms.Localkms
 import dev.trustbloc.wallet.sdk.oauth2.Oauth2
 import dev.trustbloc.wallet.sdk.openid4ci.*
@@ -22,7 +19,6 @@ import okhttp3.*
 import org.junit.Before
 import org.junit.Test
 import walletsdk.kmsStorage.KmsStore
-import java.io.IOException
 import java.net.URI
 
 
@@ -51,8 +47,9 @@ class IntegrationTest {
 
         val crypto = kms.crypto
 
-        val didCreator = Creator(kms as KeyWriter)
-        val userDID = didCreator.create("ion", null)
+        val jwk = kms.create(Localkms.KeyTypeED25519)
+
+        val userDID = Didion.createLongForm(jwk)
 
         // Issue VCs
         val requestURI = BuildConfig.INITIATE_ISSUANCE_URL
@@ -130,8 +127,9 @@ class IntegrationTest {
 
         val crypto = kms.crypto
 
-        val didCreator = Creator(kms as KeyWriter)
-        val userDID = didCreator.create("ion", null)
+        val jwk = kms.create(Localkms.KeyTypeED25519)
+
+        val userDID = Didion.createLongForm(jwk)
 
         // Issue VCs
         val requestURI = BuildConfig.INITIATE_ISSUANCE_URLS_AUTH_CODE_FLOW

--- a/demo/app/android/app/src/main/kotlin/walletsdk/WalletSDK.kt
+++ b/demo/app/android/app/src/main/kotlin/walletsdk/WalletSDK.kt
@@ -2,6 +2,9 @@ package walletsdk
 
 import dev.trustbloc.wallet.sdk.api.*
 import dev.trustbloc.wallet.sdk.did.*
+import dev.trustbloc.wallet.sdk.didion.Didion
+import dev.trustbloc.wallet.sdk.didjwk.Didjwk
+import dev.trustbloc.wallet.sdk.didkey.Didkey
 import dev.trustbloc.wallet.sdk.localkms.KMS
 import dev.trustbloc.wallet.sdk.localkms.Localkms
 import dev.trustbloc.wallet.sdk.mem.ActivityLogger
@@ -34,12 +37,26 @@ class WalletSDK {
     fun createDID(didMethodType: String, didKeyType: String): DIDDocResolution {
         val kms = this.kms ?: throw java.lang.Exception("SDK is not initialized, call initSDK()")
 
-        val createDIDOpts = CreateOpts()
-        createDIDOpts.setKeyType(didKeyType)
+        val jwk = kms.create(didKeyType)
 
-        val creatorDID = Creator(kms as KeyWriter)
+        println("Created a new key. The key ID is ${jwk.id()}")
 
-        return creatorDID.create(didMethodType, createDIDOpts)
+        val doc: DIDDocResolution
+
+        if (didMethodType == "key") {
+            doc = Didkey.create(jwk)
+        } else if (didMethodType == "jwk") {
+            doc = Didjwk.create(jwk)
+        } else if (didMethodType == "ion") {
+            doc = Didion.createLongForm(jwk)
+        } else {
+            throw java.lang.Exception("DID method type $didMethodType not supported")
+        }
+
+        println("Successfully created a new did:${didMethodType} DID. The DID is ${doc.id()}")
+
+        return doc
+
     }
 
     fun createOpenID4CIInteraction(requestURI: String) : OpenID4CI {

--- a/demo/app/integration_test/openid4ci_test.dart
+++ b/demo/app/integration_test/openid4ci_test.dart
@@ -17,7 +17,7 @@ void main() async {
   print('Init SDK');
   const didResolverURI = String.fromEnvironment('DID_RESOLVER_URI');
   await walletSDKPlugin.initSDK(didResolverURI);
-  var didKeyType = '';
+  var didKeyType = 'ED25519';
   testWidgets('Testing openid4vc with a single credential', (tester) async {
     const didMethodTypes = String.fromEnvironment('WALLET_DID_METHODS');
     var didMethodTypesList = didMethodTypes.split(' ');

--- a/demo/app/ios/Runner/Tests/IntegrationTest.swift
+++ b/demo/app/ios/Runner/Tests/IntegrationTest.swift
@@ -35,9 +35,13 @@ class IntegrationTest: XCTestCase {
         let didResolver = DidNewResolver(resolverOpts, nil)!
 
         let crypto = kms.getCrypto()
+        
+        let jwk = try kms.create(LocalkmsKeyTypeED25519)
+        
+        var error: NSError?
 
-        let didCreator = DidNewCreator(kms, nil)!
-        let userDID = try didCreator.create("ion", opts: nil)
+        let userDID = DidionCreateLongForm(jwk, &error)
+        XCTAssertNil(error)
 
         // Issue VCs
         let requestURI = ProcessInfo.processInfo.environment["INITIATE_ISSUANCE_URL"]
@@ -55,7 +59,7 @@ class IntegrationTest: XCTestCase {
         let pinRequired = try ciInteraction!.preAuthorizedCodeGrantParams().pinRequired()
         XCTAssertFalse(pinRequired)
 
-        let issuedCreds = try ciInteraction!.requestCredential(userDID.assertionMethod())
+        let issuedCreds = try ciInteraction!.requestCredential(userDID!.assertionMethod())
         XCTAssertTrue(issuedCreds.length() > 0)
 
         //Presenting VCs
@@ -110,8 +114,12 @@ class IntegrationTest: XCTestCase {
 
           let crypto = kms.getCrypto()
 
-          let didCreator = DidNewCreator(kms, nil)!
-          let userDID = try didCreator.create("ion", opts: nil)
+          let jwk = try kms.create(LocalkmsKeyTypeED25519)
+        
+          var error: NSError?
+
+          let userDID = DidionCreateLongForm(jwk, &error)
+          XCTAssertNil(error)
 
           // Issue VCs in auth flow
           let requestAuthURI = ProcessInfo.processInfo.environment["INITIATE_ISSUANCE_URLS_AUTH_CODE_FLOW"]
@@ -185,7 +193,7 @@ class IntegrationTest: XCTestCase {
                             guard let locationURL = location else {return}
                             redirectURL = locationURL.absoluteString
                             do {
-                              let issuedCreds = try ciInteraction!.requestCredential(withAuth:userDID.assertionMethod(), redirectURIWithAuthCode: redirectURL, opts: nil)
+                              let issuedCreds = try ciInteraction!.requestCredential(withAuth:userDID!.assertionMethod(), redirectURIWithAuthCode: redirectURL, opts: nil)
                               XCTAssertTrue(issuedCreds.length() > 0)
                             } catch {
                                print("Error: \(error)")

--- a/pkg/did/creator/jwk/jwk.go
+++ b/pkg/did/creator/jwk/jwk.go
@@ -49,7 +49,6 @@ func (creator *Creator) Create(vm *did.VerificationMethod) (*did.DocResolution, 
 }
 
 // Create creates a new did:key document using the given verification method.
-// Deprecated: The standalone Create function should be used instead.
 func Create(jwk *jwktype.JWK) (*did.DocResolution, error) {
 	if jwk == nil {
 		return nil, walleterror.NewInvalidSDKUsageError(

--- a/pkg/did/creator/key/key.go
+++ b/pkg/did/creator/key/key.go
@@ -39,7 +39,6 @@ func (d *Creator) Create(vm *did.VerificationMethod) (*did.DocResolution, error)
 }
 
 // Create creates a new did:key document using the given verification method.
-// Deprecated: The standalone Create function should be used instead.
 func Create(jwk *jwktype.JWK) (*did.DocResolution, error) {
 	if jwk == nil {
 		return nil, walleterror.NewInvalidSDKUsageError(

--- a/test/integration/pkg/helpers/openid4ci.go
+++ b/test/integration/pkg/helpers/openid4ci.go
@@ -38,37 +38,24 @@ func NewCITestHelper(t *testing.T, didMethod string, keyType string) *CITestHelp
 	kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
 	require.NoError(t, err)
 
+	if keyType == "" {
+		keyType = localkms.KeyTypeED25519
+	}
+
+	jwk, err := kms.Create(keyType)
+	require.NoError(t, err)
+
 	var didDoc *api.DIDDocResolution
 
 	switch didMethod {
 	case "key":
-		if keyType == "" {
-			keyType = localkms.KeyTypeED25519
-		}
-
-		jwk, err := kms.Create(keyType)
-		require.NoError(t, err)
 
 		didDoc, err = didkey.Create(jwk)
 		require.NoError(t, err)
 	case "jwk":
-		if keyType == "" {
-			keyType = localkms.KeyTypeED25519
-		}
-
-		jwk, err := kms.Create(keyType)
-		require.NoError(t, err)
-
 		didDoc, err = didjwk.Create(jwk)
 		require.NoError(t, err)
 	case "ion":
-		if keyType == "" {
-			keyType = localkms.KeyTypeED25519
-		}
-
-		jwk, err := kms.Create(keyType)
-		require.NoError(t, err)
-
 		didDoc, err = didion.CreateLongForm(jwk)
 		require.NoError(t, err)
 	default:

--- a/test/integration/pkg/helpers/openid4vp.go
+++ b/test/integration/pkg/helpers/openid4vp.go
@@ -43,37 +43,23 @@ func NewVPTestHelper(t *testing.T, didMethod string, keyType string) *VPTestHelp
 	kms, err := localkms.NewKMS(localkms.NewMemKMSStore())
 	require.NoError(t, err)
 
+	if keyType == "" {
+		keyType = localkms.KeyTypeED25519
+	}
+
+	jwk, err := kms.Create(keyType)
+	require.NoError(t, err)
+
 	var didDoc *api.DIDDocResolution
 
 	switch didMethod {
 	case "key":
-		if keyType == "" {
-			keyType = localkms.KeyTypeED25519
-		}
-
-		jwk, err := kms.Create(keyType)
-		require.NoError(t, err)
-
 		didDoc, err = didkey.Create(jwk)
 		require.NoError(t, err)
 	case "jwk":
-		if keyType == "" {
-			keyType = localkms.KeyTypeED25519
-		}
-
-		jwk, err := kms.Create(keyType)
-		require.NoError(t, err)
-
 		didDoc, err = didjwk.Create(jwk)
 		require.NoError(t, err)
 	case "ion":
-		if keyType == "" {
-			keyType = localkms.KeyTypeED25519
-		}
-
-		jwk, err := kms.Create(keyType)
-		require.NoError(t, err)
-
 		didDoc, err = didion.CreateLongForm(jwk)
 		require.NoError(t, err)
 	default:


### PR DESCRIPTION
* Updated the demo apps to use the new DID creation patterns.
* Updated the JS bindings to use the new DID creation patterns.
* Updated docs.
* Fixed an issue where the P256 key type string constant wasn't accessible from the mobile bindings.
* Other minor refactoring.