### PR TITLE
feat(app): Handle _sd credential subjects in the presentation flow

### DIFF
--- a/pkg/openid4vp/openid4vp.go
+++ b/pkg/openid4vp/openid4vp.go
@@ -928,11 +928,7 @@ func copyJSONKeysOnly(obj interface{}) interface{} {
 		return newMap
 	case verifiable.CustomFields:
 		newMap := make(map[string]interface{})
-
-		for k, v := range jsonObj {
-			newMap[k] = copyJSONKeysOnly(v)
-		}
-
+		populateClaimKeys(newMap, jsonObj)
 		return newMap
 	case []interface{}:
 		newSlice := make([]interface{}, len(jsonObj))
@@ -944,5 +940,22 @@ func copyJSONKeysOnly(obj interface{}) interface{} {
 		return newSlice
 	default:
 		return empty
+	}
+}
+
+func populateClaimKeys(claimKeys, doc map[string]interface{}) {
+	for k, v := range doc {
+		if k == "_sd" {
+			continue
+		}
+
+		keys := make(map[string]interface{})
+
+		claimKeys[k] = keys
+
+		obj, ok := v.(map[string]interface{})
+		if ok {
+			populateClaimKeys(keys, obj)
+		}
 	}
 }


### PR DESCRIPTION
![hjsfgjd](https://github.com/trustbloc/wallet-sdk/assets/7862595/69d2b5e3-89c1-43fc-b174-1157a7d1c0aa)

Trust info is verfied and in the logs : 
evaulating the presention response {"allowed":true,"payload":{}} 


<img width="570" alt="Screenshot 2024-07-09 at 3 47 49 PM" src="https://github.com/trustbloc/wallet-sdk/assets/7862595/ba06e3e7-e4d4-4130-9c8a-663b029920b8">
