### PR TITLE
fix(sdk): check display length

### DIFF
--- a/pkg/credentialschema/credentialdisplay.go
+++ b/pkg/credentialschema/credentialdisplay.go
@@ -380,6 +380,10 @@ func getOverviewDisplay(
 		}
 	}
 
+	if len(credentialConfigurationSupported.LocalizedCredentialDisplays) == 0 {
+		return &CredentialOverview{}
+	}
+
 	return issuerCredentialDisplayToResolvedCredentialOverview(
 		&credentialConfigurationSupported.LocalizedCredentialDisplays[0],
 	)


### PR DESCRIPTION
The code throws panic when thre is no display data. Added length check before fecthing the first item.